### PR TITLE
Hi Jasper, these are the lines that should be adjusted (I think). But I'm not sure - I edited them blindly.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -158,6 +158,8 @@
             #!/bin/sh
             cd ${basedir}
             cp -fr ${basedir}/schema ${reports.dir}
+            git remote set-url origin git@github.com:jasperblues/spring-objective-c.git
+            git fetch origin gh-pages
             git checkout gh-pages
             git pull
             rm -fr ./coverage


### PR DESCRIPTION
In the publish.site script I'm setting the 'origin' url to
be git@github.com:jasperblues/spring-objective-c.git so the
Bamboo plan will be able to publish the docs to github site.
