### PR TITLE
Mutate initializer parameters

### DIFF
--- a/Source/Component/Initializer/TyphoonInitializer.h
+++ b/Source/Component/Initializer/TyphoonInitializer.h
@@ -48,6 +48,8 @@ typedef enum
 
 - (NSArray*)injectedParameters;
 
+- (NSArray*)parametersInjectedByValue;
+
 - (NSInvocation*)asInvocationFor:(id)classOrInstance;
 
 - (void)setComponentDefinition:(TyphoonDefinition*)definition;

--- a/Source/Component/Initializer/TyphoonInitializer.m
+++ b/Source/Component/Initializer/TyphoonInitializer.m
@@ -86,6 +86,16 @@
     return [_injectedParameters copy];
 }
 
+- (NSArray *)parametersInjectedByValue
+{
+    NSPredicate* predicate = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary* bindings)
+                              {
+                                  return [evaluatedObject isKindOfClass:[TyphoonParameterInjectedByValue class]];
+                              }];
+    return [_injectedParameters filteredArrayUsingPredicate:predicate];
+
+}
+
 - (NSInvocation*)asInvocationFor:(id)classOrInstance
 {
     if (![classOrInstance respondsToSelector:_selector])

--- a/Source/Component/Initializer/TyphoonParameterInjectedByValue.h
+++ b/Source/Component/Initializer/TyphoonParameterInjectedByValue.h
@@ -25,7 +25,7 @@
 
 @property(nonatomic, readonly) NSUInteger index;
 @property(nonatomic, readonly) TyphoonParameterInjectionType type;
-@property(nonatomic, strong, readonly) NSString* textValue;
+@property(nonatomic, strong) NSString* textValue;
 @property(nonatomic, strong, readonly) Class requiredType;
 
 - (id)initWithIndex:(NSUInteger)index value:(NSString*)value requiredTypeOrNil:(Class)requiredTypeOrNil;

--- a/Source/Factory/PropertyConfigurers/TyphoonPropertyPlaceholderConfigurer.m
+++ b/Source/Factory/PropertyConfigurers/TyphoonPropertyPlaceholderConfigurer.m
@@ -13,7 +13,9 @@
 #import "TyphoonPropertyPlaceholderConfigurer.h"
 #import "TyphoonResource.h"
 #import "TyphoonDefinition.h"
+#import "TyphoonInitializer.h"
 #import "TyphoonPropertyInjectedByValue.h"
+#import "TyphoonParameterInjectedByValue.h"
 
 @interface TyphoonPropertyInjectedByValue (PropertyPlaceHolderConfigurer)
 
@@ -109,6 +111,17 @@
 {
     for (TyphoonDefinition* definition in componentDefinitions)
     {
+        for (TyphoonParameterInjectedByValue* parameter in [definition.initializer parametersInjectedByValue]) {
+            if ([parameter.textValue hasPrefix:_prefix] && [parameter.textValue hasSuffix:_suffix])
+            {
+                NSString* key = [parameter.textValue substringFromIndex:[_prefix length]];
+                key = [key substringToIndex:[key length] - [_suffix length]];
+                NSString* value = [_properties valueForKey:key];
+                NSLog(@"Setting property '%@' to value '%@'", key, value);
+                parameter.textValue = value;
+            }
+        }
+        
         for (TyphoonPropertyInjectedByValue* property in [definition propertiesInjectedByValue])
         {
             if ([property.textValue hasPrefix:_prefix] && [property.textValue hasSuffix:_suffix])

--- a/Tests/Factory/Mutator/PropertyConfigurer/TyphoonPropertyPlaceholderConfigurerTests.m
+++ b/Tests/Factory/Mutator/PropertyConfigurer/TyphoonPropertyPlaceholderConfigurerTests.m
@@ -34,6 +34,22 @@
     NSLog(@"Properties: %@", properties);
 }
 
+- (void)test_mutates_initializer_values
+{
+    TyphoonComponentFactory* factory = [[TyphoonComponentFactory alloc] init];
+    TyphoonDefinition* knightDefinition = [[TyphoonDefinition alloc] initWithClass:[Knight class] key:@"knight"];
+    knightDefinition.initializer = [[TyphoonInitializer alloc] init];
+    knightDefinition.initializer.selector = @selector(initWithQuest:damselsRescued:);
+    [knightDefinition.initializer injectParameterAt:1 withValueAsText:@"${damsels.rescued}" requiredTypeOrNil:nil];
+    [factory register:knightDefinition];
+    
+    [_configurer mutateComponentDefinitionsIfRequired:[factory registry]];
+    
+    Knight* knight = [factory componentForType:[Knight class]];
+    assertThatUnsignedLongLong(knight.damselsRescued, equalToUnsignedLongLong(12));
+    
+}
+
 - (void)test_mutates_property_values
 {
     TyphoonComponentFactory* factory = [[TyphoonComponentFactory alloc] init];


### PR DESCRIPTION
Hi there,

I've added support for mutable initializer parameters in the placeholder configurer, so value of parameters of initializers can also be taken from configuration files.

I've made the textValue property of TyphoonParameterInjectedByValue.h readwrite. I don't know why this was readonly, making it readwrite doesn't seem to break any test.

Thanks!
