### PR TITLE
Fix bug in injectProperties when dealing with subclassing

### DIFF
--- a/Source/Factory/TyphoonComponentFactory.m
+++ b/Source/Factory/TyphoonComponentFactory.m
@@ -168,7 +168,7 @@ static TyphoonComponentFactory* defaultFactory;
     Class class = [instance class];
     for (TyphoonDefinition* definition in _registry)
     {
-        if(definition.type == class || [definition.type isSubclassOfClass:class])
+        if(definition.type == class || [class isSubclassOfClass:definition.type])
         {
             [self injectPropertyDependenciesOn:instance withDefinition:definition];
         }

--- a/Tests/Factory/TyphoonComponentFactoryTests.m
+++ b/Tests/Factory/TyphoonComponentFactoryTests.m
@@ -221,4 +221,30 @@ static NSString* const DEFAULT_QUEST = @"quest";
 
 }
 
+- (void)test_injectProperties_subclassing
+{
+    [_componentFactory register:[TyphoonDefinition withClass:[Knight class] properties:^(TyphoonDefinition* definition)
+                                 {
+                                     [definition injectProperty:@selector(quest)];
+                                 }]];
+    [_componentFactory register:[TyphoonDefinition withClass:[CavalryMan class] properties:^(TyphoonDefinition* definition)
+                                 {
+                                     [definition injectProperty:@selector(hitRatio) withValueAsText:@"3.0"];
+                                 }]];
+    [_componentFactory register:[TyphoonDefinition withClass:[CampaignQuest class] key:@"quest"]];
+    
+    CavalryMan* cavelryMan = [[CavalryMan alloc] init];
+    [_componentFactory injectProperties:cavelryMan];
+    
+    assertThat(cavelryMan.quest, notNilValue());
+    assertThatFloat(cavelryMan.hitRatio, equalToFloat(3.0f));
+    
+    Knight* knight = [[Knight alloc] init];
+    [_componentFactory injectProperties:knight];
+    
+    assertThat(knight.quest, notNilValue());
+    
+}
+
+
 @end


### PR DESCRIPTION
https://github.com/jasperblues/Typhoon/pull/15 has a bug where Knight would try to be injected with definitions from CavelryMan and CavelryMan would not be injected with definitions from Knight.

I've fixed this and added a unit test.

However it does raise the question what should be injected when there is a definition of quest that is different for CavelryMan and Knight? I would expect CavelryMan definition to override the Knight definition however currently it is last definition wins.

How does Typhoon handle this normally?
