### PR TITLE
Improve circular dependencies resolution.

### DIFF
--- a/Source/Factory/InstanceBuilder/TyphoonComponentFactory+InstanceBuilder.m
+++ b/Source/Factory/InstanceBuilder/TyphoonComponentFactory+InstanceBuilder.m
@@ -62,6 +62,7 @@
         instance = objc_msgSend(instance, @selector(init));
     }
 
+    [_currentlyResolvingReferences setValue:instance forKey:definition.key];
     [self injectPropertyDependenciesOn:instance withDefinition:definition];
     [self injectCircularDependenciesOn:instance];
 
@@ -322,7 +323,6 @@
         [circularDependencies setValue:componentKey forKey:propertyName];
         NSLog(@"$$$$$$$$$$$$ Circular now: %@", [instance circularDependentProperties]);
     }
-    [_currentlyResolvingReferences setObject:instance forKey:componentKey];
 }
 
 - (void)injectCircularDependenciesOn:(__autoreleasing id <TyphoonIntrospectiveNSObject>)instance

--- a/Tests/Factory/Shared/TyphoonSharedComponentFactoryTests.m
+++ b/Tests/Factory/Shared/TyphoonSharedComponentFactoryTests.m
@@ -157,10 +157,14 @@
     ClassADependsOnB* classA = [_circularDependenciesFactory componentForKey:@"classA"];
     NSLog(@"Dependency on B: %@", classA.dependencyOnB);
     assertThat(classA.dependencyOnB, notNilValue());
+    assertThat(classA, equalTo(classA.dependencyOnB.dependencyOnA));
+    assertThat([classA.dependencyOnB class], equalTo([ClassBDependsOnA class]));
 
     ClassBDependsOnA* classB = [_circularDependenciesFactory componentForKey:@"classB"];
     NSLog(@"Dependency on A: %@", classB.dependencyOnA);
     assertThat(classB.dependencyOnA, notNilValue());
+    assertThat(classB, equalTo(classB.dependencyOnA.dependencyOnB));
+    assertThat([classB.dependencyOnA class], equalTo([ClassADependsOnB class]));
 
 }
 
@@ -169,10 +173,14 @@
     ClassADependsOnB* classA = [_circularDependenciesFactory componentForType:[ClassADependsOnB class]];
     NSLog(@"Dependency on B: %@", classA.dependencyOnB);
     assertThat(classA.dependencyOnB, notNilValue());
+    assertThat(classA, equalTo(classA.dependencyOnB.dependencyOnA));
+    assertThat([classA.dependencyOnB class], equalTo([ClassBDependsOnA class]));
 
     ClassBDependsOnA* classB = [_circularDependenciesFactory componentForType:[ClassBDependsOnA class]];
     NSLog(@"Dependency on A: %@", classB.dependencyOnA);
     assertThat(classB.dependencyOnA, notNilValue());
+    assertThat(classB, equalTo(classB.dependencyOnA.dependencyOnB));
+    assertThat([classB.dependencyOnA class], equalTo([ClassADependsOnB class]));
 
 }
 


### PR DESCRIPTION
TODO: More complex setups cause infinite recursion.

Related to #25.

This is the small fix I talked about, but while it fixes the test and creates a good object graph, when I tried with a little more complex object graph, some other part of Typhoon start breaking down.

I have done a little test, and it also works for singleton scoped objects.
