### PR TITLE
Circular dependency broken test (commented out).

### DIFF
--- a/Tests/Factory/Block/CircularDependenciesAssembly.m
+++ b/Tests/Factory/Block/CircularDependenciesAssembly.m
@@ -15,6 +15,9 @@
 #import "TyphoonDefinition.h"
 #import "ClassADependsOnB.h"
 #import "ClassBDependsOnA.h"
+#import "ClassCDependsOnDAndE.h"
+#import "ClassDDependsOnC.h"
+#import "ClassEDependsOnC.h"
 
 
 @implementation CircularDependenciesAssembly
@@ -35,5 +38,32 @@
         [definition injectProperty:@selector(dependencyOnA) withDefinition:[self classA]];
     }];
 }
+
+/*
+- (id)classC
+{
+    return [TyphoonDefinition withClass:[ClassCDependsOnDAndE class] properties:^(TyphoonDefinition *definition)
+    {
+        [definition injectProperty:@selector(dependencyOnD) withDefinition:[self classD]];
+        [definition injectProperty:@selector(dependencyOnE) withDefinition:[self classE]];
+    }];
+}
+
+- (id)classD
+{
+    return [TyphoonDefinition withClass:[ClassDDependsOnC class] properties:^(TyphoonDefinition *definition)
+    {
+        [definition injectProperty:@selector(dependencyOnC) withDefinition:[self classC]];
+    }];
+}
+
+- (id)classE
+{
+    return [TyphoonDefinition withClass:[ClassEDependsOnC class] properties:^(TyphoonDefinition *definition)
+    {
+        [definition injectProperty:@selector(dependencyOnC) withDefinition:[self classC]];
+    }];
+}
+*/
 
 @end

--- a/Tests/Factory/Shared/TyphoonSharedComponentFactoryTests.m
+++ b/Tests/Factory/Shared/TyphoonSharedComponentFactoryTests.m
@@ -17,6 +17,9 @@
 #import "TyphoonSharedComponentFactoryTests.h"
 #import "ClassBDependsOnA.h"
 #import "ClassADependsOnB.h"
+#import "ClassCDependsOnDAndE.h"
+#import "ClassDDependsOnC.h"
+#import "ClassEDependsOnC.h"
 
 @implementation TyphoonSharedComponentFactoryTests
 
@@ -184,5 +187,22 @@
 
 }
 
+/*
+- (void)test_resolves_two_circular_dependencies_for_property_injected_by_reference
+{
+    ClassCDependsOnDAndE* classC = [_circularDependenciesFactory componentForKey:@"classC"];
+    assertThat(classC.dependencyOnD, notNilValue());
+    assertThat(classC.dependencyOnE, notNilValue());
+    assertThat(classC, equalTo(classC.dependencyOnD.dependencyOnC));
+    assertThat(classC, equalTo(classC.dependencyOnE.dependencyOnC));
+    assertThat([classC.dependencyOnD class], equalTo([ClassDDependsOnC class]));
+    assertThat([classC.dependencyOnE class], equalTo([ClassEDependsOnC class]));
+
+    ClassDDependsOnC* classD = [_circularDependenciesFactory componentForKey:@"classD"];
+    assertThat(classD.dependencyOnC, notNilValue());
+    assertThat(classD, equalTo(classD.dependencyOnC.dependencyOnD));
+    assertThat([classD.dependencyOnC class], equalTo([ClassCDependsOnDAndE class]));
+}
+*/
 
 @end

--- a/Tests/Model/CircularDependencies/ClassCDependsOnDAndE.h
+++ b/Tests/Model/CircularDependencies/ClassCDependsOnDAndE.h
@@ -1,0 +1,25 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  AppsQuick.ly
+//  Copyright 2012 AppsQuick.ly
+//  All Rights Reserved.
+//
+//  NOTICE: AppsQuick.ly permits you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#import <Foundation/Foundation.h>
+
+@class ClassDDependsOnC;
+@class ClassEDependsOnC;
+
+
+@interface ClassCDependsOnDAndE : NSObject
+
+@property(nonatomic, strong) ClassDDependsOnC* dependencyOnD;
+@property(nonatomic, strong) ClassEDependsOnC* dependencyOnE;
+
+@end

--- a/Tests/Model/CircularDependencies/ClassCDependsOnDAndE.m
+++ b/Tests/Model/CircularDependencies/ClassCDependsOnDAndE.m
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  AppsQuick.ly
+//  Copyright 2012 AppsQuick.ly
+//  All Rights Reserved.
+//
+//  NOTICE: AppsQuick.ly permits you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#import "ClassCDependsOnDAndE.h"
+#import "ClassDDependsOnC.h"
+#import "ClassEDependsOnC.h"
+
+
+@implementation ClassCDependsOnDAndE
+{
+
+}
+@end

--- a/Tests/Model/CircularDependencies/ClassDDependsOnC.h
+++ b/Tests/Model/CircularDependencies/ClassDDependsOnC.h
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  AppsQuick.ly
+//  Copyright 2012 AppsQuick.ly
+//  All Rights Reserved.
+//
+//  NOTICE: AppsQuick.ly permits you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#import <Foundation/Foundation.h>
+
+@class ClassCDependsOnDAndE;
+
+
+@interface ClassDDependsOnC : NSObject
+
+@property(nonatomic, strong) ClassCDependsOnDAndE* dependencyOnC;
+
+@end

--- a/Tests/Model/CircularDependencies/ClassDDependsOnC.m
+++ b/Tests/Model/CircularDependencies/ClassDDependsOnC.m
@@ -1,0 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  AppsQuick.ly
+//  Copyright 2012 AppsQuick.ly
+//  All Rights Reserved.
+//
+//  NOTICE: AppsQuick.ly permits you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#import "ClassDDependsOnC.h"
+#import "ClassCDependsOnDAndE.h"
+
+
+@implementation ClassDDependsOnC
+{
+
+}
+@end

--- a/Tests/Model/CircularDependencies/ClassEDependsOnC.h
+++ b/Tests/Model/CircularDependencies/ClassEDependsOnC.h
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  AppsQuick.ly
+//  Copyright 2012 AppsQuick.ly
+//  All Rights Reserved.
+//
+//  NOTICE: AppsQuick.ly permits you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#import <Foundation/Foundation.h>
+
+@class ClassCDependsOnDAndE;
+
+
+@interface ClassEDependsOnC : NSObject
+
+@property(nonatomic, strong) ClassCDependsOnDAndE* dependencyOnC;
+
+@end

--- a/Tests/Model/CircularDependencies/ClassEDependsOnC.m
+++ b/Tests/Model/CircularDependencies/ClassEDependsOnC.m
@@ -1,0 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  AppsQuick.ly
+//  Copyright 2012 AppsQuick.ly
+//  All Rights Reserved.
+//
+//  NOTICE: AppsQuick.ly permits you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#import "ClassEDependsOnC.h"
+#import "ClassCDependsOnDAndE.h"
+
+
+@implementation ClassEDependsOnC
+{
+
+}
+@end

--- a/Tests/Resources/CircularDependenciesAssembly.xml
+++ b/Tests/Resources/CircularDependenciesAssembly.xml
@@ -11,5 +11,18 @@
         <property name="dependencyOnA" ref="classA"/>
     </component>
 
+    <component class="ClassCDependsOnDAndE" key="classC" scope="prototype">
+        <property name="dependencyOnD" ref="classD"/>
+        <property name="dependencyOnE" ref="classE"/>
+    </component>
+
+    <component class="ClassDDependsOnC" key="classD" scope="prototype">
+        <property name="dependencyOnC" ref="classC"/>
+    </component>
+
+    <component class="ClassEDependsOnC" key="classE" scope="prototype">
+        <property name="dependencyOnC" ref="classC"/>
+    </component>
+
 </assembly>
 

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		65EB6978177F61A500391D0B /* ClassDDependsOnC.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EB6977177F61A500391D0B /* ClassDDependsOnC.m */; };
+		65EB697B177F61BE00391D0B /* ClassEDependsOnC.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EB697A177F61BE00391D0B /* ClassEDependsOnC.m */; };
+		65EB697E177F626B00391D0B /* ClassCDependsOnDAndE.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EB697D177F626B00391D0B /* ClassCDependsOnDAndE.m */; };
 		6B3F399716ABF8E5001A601C /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B3F399616ABF8E5001A601C /* SenTestingKit.framework */; };
 		6B3F399916ABF8E5001A601C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B3F399816ABF8E5001A601C /* Cocoa.framework */; };
 		6B3F39A316ABF8E5001A601C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6B3F39A116ABF8E5001A601C /* InfoPlist.strings */; };
@@ -197,6 +200,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		65EB6976177F61A500391D0B /* ClassDDependsOnC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClassDDependsOnC.h; sourceTree = "<group>"; };
+		65EB6977177F61A500391D0B /* ClassDDependsOnC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClassDDependsOnC.m; sourceTree = "<group>"; };
+		65EB6979177F61BE00391D0B /* ClassEDependsOnC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClassEDependsOnC.h; sourceTree = "<group>"; };
+		65EB697A177F61BE00391D0B /* ClassEDependsOnC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClassEDependsOnC.m; sourceTree = "<group>"; };
+		65EB697C177F626B00391D0B /* ClassCDependsOnDAndE.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClassCDependsOnDAndE.h; sourceTree = "<group>"; };
+		65EB697D177F626B00391D0B /* ClassCDependsOnDAndE.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClassCDependsOnDAndE.m; sourceTree = "<group>"; };
 		6B3F397416ABF854001A601C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6B3F399516ABF8E5001A601C /* Tests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B3F399616ABF8E5001A601C /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -654,10 +663,16 @@
 		BA798988DA6C716409711479 /* CircularDependencies */ = {
 			isa = PBXGroup;
 			children = (
-				BA798C719DB799A72B877AA6 /* ClassADependsOnB.m */,
 				BA798E265F77622D00A10B49 /* ClassADependsOnB.h */,
-				BA79856D23D2E1F11B2D98A8 /* ClassBDependsOnA.m */,
+				BA798C719DB799A72B877AA6 /* ClassADependsOnB.m */,
 				BA7986806CAD48DFD9D79DF2 /* ClassBDependsOnA.h */,
+				BA79856D23D2E1F11B2D98A8 /* ClassBDependsOnA.m */,
+				65EB697C177F626B00391D0B /* ClassCDependsOnDAndE.h */,
+				65EB697D177F626B00391D0B /* ClassCDependsOnDAndE.m */,
+				65EB6976177F61A500391D0B /* ClassDDependsOnC.h */,
+				65EB6977177F61A500391D0B /* ClassDDependsOnC.m */,
+				65EB6979177F61BE00391D0B /* ClassEDependsOnC.h */,
+				65EB697A177F61BE00391D0B /* ClassEDependsOnC.m */,
 			);
 			path = CircularDependencies;
 			sourceTree = "<group>";
@@ -1036,6 +1051,9 @@
 				BA798EA4DDC838A133459796 /* TyphoonTypeConvertedCollectionValue.m in Sources */,
 				BA7982E1BDA4C7924D7285BB /* TyphoonPropertyInjectedAsCollectionTests.m in Sources */,
 				B594F87F174DF32800BF5DC5 /* TyphoonParameterInjectedByRawValue.m in Sources */,
+				65EB6978177F61A500391D0B /* ClassDDependsOnC.m in Sources */,
+				65EB697B177F61BE00391D0B /* ClassEDependsOnC.m in Sources */,
+				65EB697E177F626B00391D0B /* ClassCDependsOnDAndE.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This is related to #25 and #26.

This is the setup that still fails using circular dependencies (both Blocks and XML). The block factory fails before being able to build the factory, while the XML fails trying to resolve the circular dependency.
