### PR TITLE
Unload when a new post processor is added.

### DIFF
--- a/Source/Factory/TyphoonComponentFactory.m
+++ b/Source/Factory/TyphoonComponentFactory.m
@@ -186,6 +186,9 @@ static TyphoonComponentFactory* defaultFactory;
 {
     LogTrace(@"Attaching post processor: %@", postProcessor);
     [_postProcessors addObject:postProcessor];
+    if ([self isLoaded]) {
+        [self unload];
+    }
 }
 
 - (void)injectProperties:(id)instance

--- a/Tests/Factory/Config/Patcher/TyphoonPatcherTests.m
+++ b/Tests/Factory/Config/Patcher/TyphoonPatcherTests.m
@@ -52,4 +52,30 @@
 
 }
 
+- (void)test_allows_patching_out_a_loaded_component_with_a_mock
+{
+    MiddleAgesAssembly* assembly = [MiddleAgesAssembly assembly];
+    TyphoonComponentFactory* factory = [TyphoonBlockComponentFactory factoryWithAssembly:assembly];
+    [factory componentForKey:@"knight"];
+    //at this point, patching a loaded factory will not pass.
+    
+    TyphoonPatcher* patcher = [[TyphoonPatcher alloc] init];
+    [patcher patchDefinition:[assembly knight] withObject:^id
+     {
+         Knight* mockKnight = mock([Knight class]);
+         [given([mockKnight favoriteDamsels]) willReturn:@[
+                                                           @"Mary",
+                                                           @"Janezzz"
+                                                           ]];
+         
+         return mockKnight;
+     }];
+    
+    [factory attachPostProcessor:patcher];
+    
+    Knight* knight = [factory componentForKey:@"knight"];
+    assertThatBool([knight favoriteDamsels].count > 0, is(equalToBool(YES)));
+    LogDebug(@"Damsels: %@", [knight favoriteDamsels]);
+    
+}
 @end


### PR DESCRIPTION
When TyphoonFactory has had its first component extracted, any future patcher will not be able to influence the get component.

Enforced by unloading when a new post processor is added.
