### PR TITLE
.gitattributes and filter to add copyright header

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pbxproj binary merge=union
+*.[hm] filter=typhoonheader

--- a/Scripts/typhoonheader
+++ b/Scripts/typhoonheader
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby -wKU
+
+# To use this script, add the following keys to your local config.
+# git config filter.typhoonheader.smudge 'cat'
+# git config filter.typhoonheader.clean '`git rev-parse --git-dir`/../scripts/typhoonheader'
+
+TYPHOON_HEADER = <<EOS
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Jasper Blues & Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+EOS
+
+XCODE_HEADER = Regexp.new(<<EOS)
+\\A//
+//  .*
+//  .*
+//
+//  Created by .* on \\d\\d/\\d\\d/\\d\\d\\.
+//  Copyright \\(c\\) \\d{4} .*\\. All rights reserved\\.
+//
+EOS
+
+input = STDIN.read
+output = STDOUT
+
+if input.start_with? TYPHOON_HEADER
+  output.write input
+elsif XCODE_HEADER.match(input)
+  output.puts TYPHOON_HEADER
+  output.write input.gsub(XCODE_HEADER, '')
+else
+  output.puts TYPHOON_HEADER
+  output.write input
+end


### PR DESCRIPTION
The filter script appends Typhoon header when adding/modifying files, and removes standard Xcode header if found.

It seems to work for the simple cases I have tried:
- Create a new file without any kind of header.
- Create a new file with Xcode header.
- Create a new file with Typhoon header.
- Modify an existing file with Xcode header.
- Modify an existing file with Typhoon header.

It did me something weird after a reset. Status keep telling me there was changes in a file, and there weren’t changes any more.

One gotcha: you will not have the correct header until you checkout that file again. The changes happen from the working directory to the staging area, but do not persist in the working directory until a checkout of that file happens.

Probably needs a change in the readme/contributing page to tell other contributors to “install” the filter. Nothing happens if the filter is not defined (not even a warning).

See #116
