### PR TITLE
fix compiler warnings

### DIFF
--- a/Source/Factory/Provider/TyphoonAssistedFactoryMethodCreator.m
+++ b/Source/Factory/Provider/TyphoonAssistedFactoryMethodCreator.m
@@ -65,6 +65,7 @@
             break;
         }
     }
+#pragma unused(found)
     NSCAssert(found, @"protocol doesn't support factory method with name %@", NSStringFromSelector(methodName));
     free(methodDescriptions);
 

--- a/Source/Factory/Provider/TyphoonAssistedFactoryMethodInitializerClosure.m
+++ b/Source/Factory/Provider/TyphoonAssistedFactoryMethodInitializerClosure.m
@@ -48,7 +48,9 @@
         _methodSignature = methodSignature;
         _closedMethodSignature = [_returnType instanceMethodSignatureForSelector:_initSelector];
 
+#ifdef DEBUG
         NSUInteger count = _closedMethodSignature.numberOfArguments - 2;
+#endif
         NSAssert([self validateInitializerParameterCount:count], @"parameter map for %s do not fill all %lu parameters", sel_getName(_initSelector), (unsigned long) count);
     }
 

--- a/Source/TypeConversion/Converters/TyphoonPrimitiveTypeConverter.m
+++ b/Source/TypeConversion/Converters/TyphoonPrimitiveTypeConverter.m
@@ -152,7 +152,7 @@
         case TyphoonPrimitiveTypeVoid: {
             /* Inject all pointers to void and unknown pointers just like void pointers */
             if (requiredType.isPointer) {
-                void *pointer = [self convertToInt:textValue];
+                void *pointer = (void *)[self convertToInt:textValue];
                 value = [NSValue valueWithPointer:pointer];
             }
             else {


### PR DESCRIPTION
we use Typhoon with Cocoapods and this cause warnings to appear in our build or force us to inhibit all warnings
