### PR TITLE
Fixing compilation issue on Release (Archive):

### DIFF
--- a/Source/Factory/Provider/TyphoonAssistedFactoryMethodInitializerClosure.m
+++ b/Source/Factory/Provider/TyphoonAssistedFactoryMethodInitializerClosure.m
@@ -50,8 +50,8 @@
 
 #ifdef DEBUG
         NSUInteger count = _closedMethodSignature.numberOfArguments - 2;
-#endif
         NSAssert([self validateInitializerParameterCount:count], @"parameter map for %s do not fill all %lu parameters", sel_getName(_initSelector), (unsigned long) count);
+#endif
     }
 
     return self;


### PR DESCRIPTION
Tried to build Archive of Typhoon and got simple to fix error:

`/Users/andrew/Desktop/Typhoon/Source/Factory/Provider/TyphoonAssistedFactoryMethodInitializerClosure.m:54:58: error: use of undeclared identifier 'count'
        NSAssert([self validateInitializerParameterCount:count], @"parameter map for %s do not fill all %lu parameters", sel_getName(_initSelector), (unsigned long) count);
                                                         ^
In file included from /Users/andrew/Desktop/Typhoon/Source/Factory/Provider/TyphoonAssistedFactoryMethodInitializerClosure.m:1:
`
