### PR TITLE
Change README code snippet indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ___Without dependency injection, you might have a View Controller like this___:
 
 ```objective-c
 
--(id) init 
+- (id)init 
 {
     self = [super init];
     if (self) 
@@ -66,7 +66,7 @@ ___And now, it simply becomes___:
 
 ```objective-c
 
--(id) initWithWeatherClient:(id<WeatherClient>)weatherClient
+- (id)initWithWeatherClient:(id<WeatherClient>)weatherClient
 {
     self = [super init];
     if (self) 


### PR DESCRIPTION
It was using a one-space indent, then a random 4-space in one place. Made it all four space, as that appears to be the convention in this repo (looking through the code).
