### PR TITLE
Cast the call to objc_msgSend to the adequate type

### DIFF
--- a/Source/Factory/Block/TyphoonAssemblyDefinitionBuilder.m
+++ b/Source/Factory/Block/TyphoonAssemblyDefinitionBuilder.m
@@ -197,7 +197,7 @@ static id objc_msgSend_InjectionArguments(id target, SEL selector, NSMethodSigna
         return (__bridge id) result;
     }
     else {
-        return objc_msgSend(target, selector);
+        return ((id (*)(id, SEL))objc_msgSend)(target, selector);
     }
 }
 


### PR DESCRIPTION
The last update to LLVM made it necesary to cast objc_msgSend to the
desired type before using it (it takes no arguments in it's definition).
This in combination with changed build settings in CocoaPods 0.36 beta
caused Typhoon not to compile.