### PR TITLE
Bug fix getting Class from ClassName with spaces in Bundle Name

### DIFF
--- a/Source/Utils/TyphoonIntrospectionUtils.m
+++ b/Source/Utils/TyphoonIntrospectionUtils.m
@@ -217,6 +217,7 @@ Class TyphoonClassFromString(NSString *className)
     Class clazz = NSClassFromString(className);
     if (!clazz) {
         NSString *defaultModuleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        defaultModuleName = [defaultModuleName stringByReplacingOccurrencesOfString:@" " withString:@"_"];
         clazz = NSClassFromString([defaultModuleName stringByAppendingFormat:@".%@",className]);
     }
     if (!clazz) {


### PR DESCRIPTION
If there is a space in the Product Name (CFBundleName),
NSClassFromString will not find the class. Need to convert the “ “ to
“_” for the defaultModuleName before calling NSClassFromString.