### PR TITLE
Make TyphoonStoryboard accept id<TyphoonComponentFactory> instead of TyphoonComponentFactory

### DIFF
--- a/Source/ios/Storyboard/TyphoonStoryboard.h
+++ b/Source/ios/Storyboard/TyphoonStoryboard.h
@@ -33,11 +33,11 @@
  */
 @interface TyphoonStoryboard : UIStoryboard
 
-@property(nonatomic, strong) TyphoonComponentFactory *factory;
+@property(nonatomic, strong) id<TyphoonComponentFactory> factory;
 
 + (TyphoonStoryboard *)storyboardWithName:(NSString *)name bundle:(NSBundle *)storyboardBundleOrNil;
 
-+ (TyphoonStoryboard *)storyboardWithName:(NSString *)name factory:(TyphoonComponentFactory *)factory bundle:(NSBundle *)bundleOrNil;
++ (TyphoonStoryboard *)storyboardWithName:(NSString *)name factory:(id<TyphoonComponentFactory>)factory bundle:(NSBundle *)bundleOrNil;
 
 @end
 

--- a/Source/ios/Storyboard/TyphoonStoryboard.m
+++ b/Source/ios/Storyboard/TyphoonStoryboard.m
@@ -50,7 +50,7 @@ static const char *kTyphoonKey;
     return [self storyboardWithName:name factory:nil bundle:storyboardBundleOrNil];
 }
 
-+ (TyphoonStoryboard *)storyboardWithName:(NSString *)name factory:(TyphoonComponentFactory *)factory bundle:(NSBundle *)bundleOrNil
++ (TyphoonStoryboard *)storyboardWithName:(NSString *)name factory:(id<TyphoonComponentFactory>)factory bundle:(NSBundle *)bundleOrNil
 {
     TyphoonStoryboard *storyboard = (id) [super storyboardWithName:name bundle:bundleOrNil];
     storyboard.factory = factory;


### PR DESCRIPTION
This should make it easier to use this class from Swift making it
possible to pass assemblies to class constructor without casting.