### PR TITLE
Support bundle names that have a dash in them

### DIFF
--- a/Source/Utils/TyphoonIntrospectionUtils.m
+++ b/Source/Utils/TyphoonIntrospectionUtils.m
@@ -235,7 +235,8 @@ Class TyphoonClassFromString(NSString *className)
     Class clazz = NSClassFromString(className);
     if (!clazz) {
         NSString *defaultModuleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleExecutable"];
-        defaultModuleName = [defaultModuleName stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+        defaultModuleName = [[defaultModuleName stringByReplacingOccurrencesOfString:@" " withString:@"_"]
+                stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
         clazz = NSClassFromString([defaultModuleName stringByAppendingFormat:@".%@", className]);
     }
     if (!clazz) {


### PR DESCRIPTION
The module name replaces dashes in the bundle name with an underscore, so the code to calculate the defaultModuleName needs to replace a dash as well as a space with an underscore.

This is necessary for targets or bundles that have dash in the same, which specifically in my project's case is the `-cal` target used by Calabash.