### PR TITLE
Assembly injection fix

### DIFF
--- a/Source/Definition/Injections/TyphoonInjectionByComponentFactory.m
+++ b/Source/Definition/Injections/TyphoonInjectionByComponentFactory.m
@@ -12,6 +12,14 @@
 
 #import "TyphoonInjectionByComponentFactory.h"
 #import "NSInvocation+TCFUnwrapValues.h"
+#import "TyphoonIntrospectionUtils.h"
+#import "TyphoonAssembly.h"
+
+@interface TyphoonAssembly (Activation)
+
+- (void)activateWithFactory:(TyphoonComponentFactory *)factory collaborators:(NSSet *)collaborators;
+
+@end
 
 @implementation TyphoonInjectionByComponentFactory
 
@@ -19,6 +27,19 @@
 
 - (void)valueToInjectWithContext:(TyphoonInjectionContext *)context completion:(TyphoonInjectionValueBlock)result
 {
+    id factoryType = context.destinationType.classOrProtocol;
+    
+    if (IsClass(factoryType)) {
+        Class factoryClass = factoryType;
+        BOOL isAssemblySubclass = [factoryClass isSubclassOfClass:[TyphoonAssembly class]];
+        if (isAssemblySubclass) {
+            id assembly = [[factoryClass alloc] init];
+            [assembly activateWithFactory:context.factory collaborators:nil];
+            result(assembly);
+            return;
+        }
+    }
+    
     result(context.factory);
 }
 

--- a/Tests/Definition/Injection Aware/ComponentFactoryAwareAssembly.h
+++ b/Tests/Definition/Injection Aware/ComponentFactoryAwareAssembly.h
@@ -16,7 +16,9 @@
 
 - (id)injectionAwareObject;
 
-- (id)injectionByProperty;
+- (id)injectionFactoryByProperty;
+
+- (id)injectionAssemblyByProperty;
 
 - (id)injectionByInitialization;
 

--- a/Tests/Definition/Injection Aware/ComponentFactoryAwareAssembly.m
+++ b/Tests/Definition/Injection Aware/ComponentFactoryAwareAssembly.m
@@ -21,10 +21,17 @@
     return [TyphoonDefinition withClass:[ComponentFactoryAwareObject class]];
 }
 
-- (id)injectionByProperty
+- (id)injectionFactoryByProperty
 {
     return [TyphoonDefinition withClass:[ComponentFactoryAwareObject class] configuration:^(TyphoonDefinition *definition) {
         [definition injectProperty:@selector(componentFactory) with:self];
+    }];
+}
+
+- (id)injectionAssemblyByProperty
+{
+    return [TyphoonDefinition withClass:[ComponentFactoryAwareObject class] configuration:^(TyphoonDefinition *definition) {
+        [definition injectProperty:@selector(assembly) with:self];
     }];
 }
 

--- a/Tests/Definition/Injection Aware/TyphoonComponentFactoryAwareTests.m
+++ b/Tests/Definition/Injection Aware/TyphoonComponentFactoryAwareTests.m
@@ -38,13 +38,19 @@
 
 - (void)test_factory_injection_by_property
 {
-    object = [factory injectionByProperty];
+    object = [factory injectionFactoryByProperty];
+    XCTAssertTrue(object.factory == factory);
+}
+
+- (void)test_assembly_injection_by_property
+{
+    object = [factory injectionAssemblyByProperty];
     XCTAssertTrue(object.factory == factory);
 }
 
 - (void)test_factory_injection_by_initialization
 {
-    object = [factory injectionByProperty];
+    object = [factory injectionFactoryByProperty];
     XCTAssertTrue(object.factory == factory);
 }
 
@@ -60,5 +66,16 @@
     XCTAssertTrue(object.factory == factory);
 }
 
+- (void)test_assembly_injection_by_property_class_check {
+    object = [factory injectionAssemblyByProperty];
+    BOOL isRightClass = [object.assembly isKindOfClass:[ComponentFactoryAwareAssembly class]];
+    XCTAssertTrue(isRightClass);
+}
+
+- (void)test_assembly_injection_by_property_assembly_type_class_check {
+    object = [factory injectionByPropertyAssemblyType];
+    BOOL isRightClass = [object.assembly isKindOfClass:[ComponentFactoryAwareAssembly class]];
+    XCTAssertTrue(isRightClass);
+}
 
 @end


### PR DESCRIPTION
Added a quick-fix for injection by component factory mechanism. Now, when you call *[definition injectProperty:@selector(assembly) with:self];*, the concrete subclass of *TyphoonAssembly* backed by *TyphoonComponentFactory* is injected.

It fixes the problems with performing class and protocol checks on injected assembly.

Though we still need the better solution.