### PR TITLE
Improve introspection performance

### DIFF
--- a/Source/Utils/TyphoonIntrospectionUtils.m
+++ b/Source/Utils/TyphoonIntrospectionUtils.m
@@ -230,14 +230,38 @@ NSString *TyphoonTypeStringFor(id classOrProtocol)
     }
 }
 
+NSString *TyphoonDefaultModuleName()
+{
+    static NSString *defaultModuleName;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        defaultModuleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleExecutable"];
+        defaultModuleName = [[defaultModuleName stringByReplacingOccurrencesOfString:@" " withString:@"_"]
+                             stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
+    });
+    return defaultModuleName;
+}
+
+BOOL TyphoonIsInvalidClassName(NSString *className)
+{
+    if (className.length == 0) {
+        return YES;
+    }
+    if ([className isEqualToString:@"?"]) {
+        return YES;
+    }
+    return NO;
+}
+
 Class TyphoonClassFromString(NSString *className)
 {
+    if (TyphoonIsInvalidClassName(className)) {
+        return Nil;
+    }
+    
     Class clazz = NSClassFromString(className);
     if (!clazz) {
-        NSString *defaultModuleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleExecutable"];
-        defaultModuleName = [[defaultModuleName stringByReplacingOccurrencesOfString:@" " withString:@"_"]
-                stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
-        clazz = NSClassFromString([defaultModuleName stringByAppendingFormat:@".%@", className]);
+        clazz = NSClassFromString([TyphoonDefaultModuleName() stringByAppendingFormat:@".%@", className]);
     }
     if (!clazz) {
         /**


### PR DESCRIPTION
Hey folks!

We are using Typhoon extensively in our application (works like a charm, thanks!). However, recent tests on older devices (4S) showed that Typhoon took quite a lot of time on startup, delaying the launch of application. It turns out that most of this time can be cut down with a couple of minor fixes.

The first thing taking a whole lot of time happens in `TyphoonClassFromString`. It turns out that `[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleExecutable"];` is a very expensive thing to do. However, we can avoid going to this fallback branch entirely by checking if `className` is 100% invalid. Two simple cases currently covered are no class name specified at all (aka empty string) and block (aka question mark). There might be more, though this was sufficient for my selfish needs right now. This sole fix cut the time spent during Typhoon initialization in half!

The second thing worth optimizing is `TyphoonTypeDescriptor`. A lot of expensive string manipulation goes on in there while parsing type name and protocol, so I rewrote it using range manipulations. It may also make sense to do the same optimization for primitive type parsing, but it's a rarer case so I decided not to touch that part for now.

All right, now the minor bitter thing - invoking `build.sh` on this tells me that the code coverage level is now below 85% - due to fallback branches on `TyphoonClassFromString` being skipped entirely. I'm not really sure what to do there because they involve some Swift stuff.

Please tell me if there's something left to do with this, I'd be glad to help. Thanks again for making the great framework!