### PR TITLE
Increased the percent of code coverage (up to 88.3)

### DIFF
--- a/Source/Factory/Assembly/TyphoonAssembly.m
+++ b/Source/Factory/Assembly/TyphoonAssembly.m
@@ -201,7 +201,13 @@ static NSMutableSet *reservedSelectorsAsStrings;
     [_factory attachPostProcessor:postProcessor];
 }
 
-
+- (id)objectForKeyedSubscript:(id)key {
+    if (!_factory) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"objectForKeyedSubscript: requires the assembly to be activated."];
+    }
+    return [_factory objectForKeyedSubscript:key];
+}
 
 //-------------------------------------------------------------------------------------------
 #pragma mark - Interface Methods

--- a/Source/Factory/TyphoonComponentFactory.h
+++ b/Source/Factory/TyphoonComponentFactory.h
@@ -62,6 +62,11 @@
 - (id)componentForKey:(NSString *)key args:(TyphoonRuntimeArguments *)args;
 
 /**
+ * You can query the factory by using object subscription syntax: _factory[@"myObject"] or even _factory[[MyObject class]]
+ */
+- (id)objectForKeyedSubscript:(id)key;
+
+/**
 * Injects the properties and methods of an object
 */
 - (void)inject:(id)instance;

--- a/Tests/Definition/TyphoonDefinitionTests.m
+++ b/Tests/Definition/TyphoonDefinitionTests.m
@@ -80,6 +80,33 @@
     @catch (NSException *e) {
         XCTAssertEqualObjects([e description], @"Subclass of NSProxy or NSObject is required.");
     }
+    
+    @try {
+        TyphoonDefinition *definition = [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+            [definition useInitializer:@selector(initWithQuest:) parameters:^(TyphoonMethod *initializer) {
+                
+            }];
+        }];
+        NSLog(@"Def: %@", definition);
+        XCTFail(@"Should've thrown exception");
+    }
+    @catch (NSException *e) {
+        XCTAssertEqualObjects([e description], @"Method 'initWithQuest:' has 1 parameters, but 0 was injected. Inject with 'nil' if necessary");
+    }
+    
+    @try {
+        TyphoonDefinition *definition = [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+            [definition useInitializer:@selector(initWithQuest:) parameters:^(TyphoonMethod *initializer) {
+                [initializer injectParameterWith:[NSObject new]];
+                [initializer injectParameterWith:[NSObject new]];
+            }];
+        }];
+        NSLog(@"Def: %@", definition);
+        XCTFail(@"Should've thrown exception");
+    }
+    @catch (NSException *e) {
+        XCTAssertEqualObjects([e description], @"Method 'initWithQuest:' has 1 parameters, but 2 was injected. ");
+    }
 }
 
 //-------------------------------------------------------------------------------------------

--- a/Tests/Definition/TyphoonDefinitionTests.m
+++ b/Tests/Definition/TyphoonDefinitionTests.m
@@ -23,6 +23,7 @@
 #import "TyphoonMethod+InstanceBuilder.h"
 #import "TyphoonDefinition+Tests.h"
 #import "ClassForNoSubclass.h"
+#import "CampaignQuest.h"
 
 @interface TyphoonDefinitionTests : XCTestCase
 @end
@@ -179,6 +180,14 @@
     XCTAssertEqual([child scope], (TyphoonScopePrototype));
 }
 
+- (void)test_throws_exception_if_parent_is_not_definition
+{
+    id parent = [NSObject new];
+    
+    TyphoonDefinition *child = [TyphoonDefinition withClass:[Knight class]];
+    
+    XCTAssertThrows([child setParent:parent]);
+}
 
 //-------------------------------------------------------------------------------------------
 #pragma mark - Copying
@@ -213,6 +222,62 @@
     [copy enumerateInjectionsOfKind:[TyphoonInjectionByCollection class] options:TyphoonInjectionsEnumerationOptionProperties usingBlock:^(id collection, id *injectionToReplace, BOOL *stop) {
         XCTAssertEqual([collection count], 2);
     }];
+}
+
+//-------------------------------------------------------------------------------------------
+#pragma mark - Injection Hooks
+//-------------------------------------------------------------------------------------------
+
+- (void)test_before_injections
+{
+    TyphoonDefinition *definition = [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+        [definition performBeforeInjections:@selector(description)];
+    }];
+    
+    XCTAssertEqual(@selector(description), [definition beforeInjections].selector);
+}
+
+- (void)test_before_injections_with_parameters_hook
+{
+    NSUInteger const damselsRescued = 100;
+    CampaignQuest *quest = [CampaignQuest new];
+    
+    TyphoonDefinition *definition = [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+        [definition performBeforeInjections:@selector(setQuest:andDamselsRescued:) parameters:^(TyphoonMethod *params) {
+            [params injectParameterWith:quest];
+            [params injectParameterWith:@(damselsRescued)];
+        }];
+    }];
+    
+    XCTAssertEqual(@selector(setQuest:andDamselsRescued:), [definition beforeInjections].selector);
+    XCTAssertEqualObjects(quest, [[definition beforeInjections].injectedParameters[0] objectInstance]);
+    XCTAssertEqualObjects(@(damselsRescued), [[definition beforeInjections].injectedParameters[1] objectInstance]);
+}
+
+- (void)test_after_injections
+{
+    TyphoonDefinition *definition = [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+        [definition performAfterInjections:@selector(description)];
+    }];
+    
+    XCTAssertEqual(@selector(description), [definition afterInjections].selector);
+}
+
+- (void)test_after_injections_with_parameters_hook
+{
+    NSUInteger const damselsRescued = 100;
+    CampaignQuest *quest = [CampaignQuest new];
+    
+    TyphoonDefinition *definition = [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+        [definition performAfterInjections:@selector(setQuest:andDamselsRescued:) parameters:^(TyphoonMethod *params) {
+            [params injectParameterWith:quest];
+            [params injectParameterWith:@(damselsRescued)];
+        }];
+    }];
+    
+    XCTAssertEqual(@selector(setQuest:andDamselsRescued:), [definition afterInjections].selector);
+    XCTAssertEqualObjects(quest, [[definition afterInjections].injectedParameters[0] objectInstance]);
+    XCTAssertEqualObjects(@(damselsRescued), [[definition afterInjections].injectedParameters[1] objectInstance]);
 }
 
 @end

--- a/Tests/Factory/Assembly/TyphoonAssemblyTests.m
+++ b/Tests/Factory/Assembly/TyphoonAssemblyTests.m
@@ -126,6 +126,19 @@
     }
 }
 
+- (void)test_before_activation_raises_exception_when_invoking_subscription
+{
+    @try {
+        MiddleAgesAssembly *assembly = [MiddleAgesAssembly assembly];
+        id result = assembly[@"test"];
+        NSLog(@"%@", result);
+        XCTFail(@"Should have thrown exception");
+    }
+    @catch (NSException *e) {
+        XCTAssertEqualObjects(@"objectForKeyedSubscript: requires the assembly to be activated.", [e description]);
+    }
+}
+
 - (void)test_after_activation_TyphoonComponentFactory_methods_are_available
 {
     MiddleAgesAssembly *assembly = [MiddleAgesAssembly assembly];

--- a/Tests/Factory/TyphoonComponentFactoryTests.m
+++ b/Tests/Factory/TyphoonComponentFactoryTests.m
@@ -269,6 +269,19 @@ static NSString *const DEFAULT_QUEST = @"quest";
 
 }
 
+- (void)test_does_not_inject_for_unknown_selector
+{
+    @try {
+        Knight *knight = [[Knight alloc] init];
+        [_componentFactory inject:knight withSelector:@selector(knight)];
+
+        XCTFail(@"Should've thrown exception");
+    }
+    @catch (NSException *e) {
+        XCTAssertEqualObjects([e description], @"Can't find definition for specified selector knight");
+    }
+}
+
 - (void)test_injectProperties_subclassing
 {
     [_componentFactory registerDefinition:[TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {

--- a/Tests/Factory/TyphoonComponentFactoryTests.m
+++ b/Tests/Factory/TyphoonComponentFactoryTests.m
@@ -146,10 +146,24 @@ static NSString *const DEFAULT_QUEST = @"quest";
     [_componentFactory registerDefinition:[TyphoonDefinition withClass:[CampaignQuest class] key:@"quest"]];
 
     Knight *knight = [_componentFactory componentForKey:@"knight"];
-
     XCTAssertNotNil(knight);
     XCTAssertTrue([knight isKindOfClass:[Knight class]]);
     XCTAssertNotNil(knight.quest);
+}
+
+- (void)test_factory_object_subscripting
+{
+    [_componentFactory registerDefinition:[TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+        [definition setKey:@"knight"];
+    }]];
+    
+    Knight *knight_var1 = _componentFactory[@"knight"];
+    XCTAssertNotNil(knight_var1);
+    XCTAssertTrue([knight_var1 isKindOfClass:[Knight class]]);
+    
+    Knight *knight_var2 = _componentFactory[[Knight class]];
+    XCTAssertNotNil(knight_var2);
+    XCTAssertTrue([knight_var2 isKindOfClass:[Knight class]]);
 }
 
 //-------------------------------------------------------------------------------------------

--- a/Tests/Factory/WeakPool/TyphoonWeakComponentsPoolTests.m
+++ b/Tests/Factory/WeakPool/TyphoonWeakComponentsPoolTests.m
@@ -35,7 +35,7 @@
         XCTAssertEqual([pool objectForKey:@"objectA"], objectA);
         XCTAssertEqual([pool objectForKey:@"objectB"], objectB);
     }
-
+    
     objectA = nil;
 
     XCTAssertNil([pool objectForKey:@"objectA"]);
@@ -45,5 +45,23 @@
     XCTAssertNil([pool objectForKey:@"objectB"]);
 }
 
+- (void)test_pool_return_all_values
+{
+    NSObject *objectA = [NSObject new];
+    NSObject *objectB = [NSObject new];
+    
+    TyphoonWeakComponentsPool *pool = [TyphoonWeakComponentsPool new];
+    
+    [pool setObject:objectA forKey:@"objectA"];
+    [pool setObject:objectB forKey:@"objectB"];
+    
+    NSArray *poolValues = [pool allValues];
+    XCTAssertEqual(poolValues.count, 2);
+    
+    [pool removeAllObjects];
+    
+    poolValues = [pool allValues];
+    XCTAssertEqual(poolValues.count, 0);
+}
 
 @end

--- a/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.h
+++ b/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonAppDelegateWithBothMethodsMock.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 30/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
 

--- a/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.h
+++ b/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.h
@@ -1,0 +1,13 @@
+//
+//  TyphoonAppDelegateWithBothMethodsMock.h
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 30/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonAppDelegateWithBothMethodsMock : NSObject
+
+@end

--- a/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.m
+++ b/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonAppDelegateWithBothMethodsMock.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 30/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "TyphoonAppDelegateWithBothMethodsMock.h"
 #import "MiddleAgesAssembly.h"

--- a/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.m
+++ b/Tests/Startup/TyphoonAppDelegateWithBothMethodsMock.m
@@ -1,0 +1,28 @@
+//
+//  TyphoonAppDelegateWithBothMethodsMock.m
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 30/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import "TyphoonAppDelegateWithBothMethodsMock.h"
+#import "MiddleAgesAssembly.h"
+#import "SimpleAssembly.h"
+
+@implementation TyphoonAppDelegateWithBothMethodsMock
+
+- (id)initialFactory
+{
+    SimpleAssembly *assembly = [SimpleAssembly new];
+    return [assembly activate];
+}
+
+- (NSArray *)initialAssemblies
+{
+    return @[
+             [MiddleAgesAssembly class]
+             ];
+}
+
+@end

--- a/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.h
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonAppDelegateWithInitialAssembliesMock.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 30/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
 

--- a/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.h
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.h
@@ -1,0 +1,13 @@
+//
+//  TyphoonAppDelegateWithInitialAssembliesMock.h
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 30/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonAppDelegateWithInitialAssembliesMock : NSObject
+
+@end

--- a/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.m
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.m
@@ -1,0 +1,21 @@
+//
+//  TyphoonAppDelegateWithInitialAssembliesMock.m
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 30/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import "TyphoonAppDelegateWithInitialAssembliesMock.h"
+#import "MiddleAgesAssembly.h"
+
+@implementation TyphoonAppDelegateWithInitialAssembliesMock
+
+- (NSArray *)initialAssemblies
+{
+    return @[
+             [MiddleAgesAssembly class]
+             ];
+}
+
+@end

--- a/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.m
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialAssembliesMock.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonAppDelegateWithInitialAssembliesMock.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 30/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "TyphoonAppDelegateWithInitialAssembliesMock.h"
 #import "MiddleAgesAssembly.h"

--- a/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.h
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonAppDelegateWithInitialFactoryMock.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 30/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
 

--- a/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.h
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.h
@@ -1,0 +1,13 @@
+//
+//  TyphoonAppDelegateWithInitialFactoryMock.h
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 30/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonAppDelegateWithInitialFactoryMock : NSObject
+
+@end

--- a/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.m
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonAppDelegateWithInitialFactoryMock.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 30/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "TyphoonAppDelegateWithInitialFactoryMock.h"
 #import "MiddleAgesAssembly.h"

--- a/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.m
+++ b/Tests/Startup/TyphoonAppDelegateWithInitialFactoryMock.m
@@ -1,0 +1,20 @@
+//
+//  TyphoonAppDelegateWithInitialFactoryMock.m
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 30/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import "TyphoonAppDelegateWithInitialFactoryMock.h"
+#import "MiddleAgesAssembly.h"
+
+@implementation TyphoonAppDelegateWithInitialFactoryMock
+
+- (id)initialFactory
+{
+    MiddleAgesAssembly *assembly = [MiddleAgesAssembly new];
+    return [assembly activate];
+}
+
+@end

--- a/Tests/Startup/TyphoonStartupTests.m
+++ b/Tests/Startup/TyphoonStartupTests.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonStartupTests.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 29/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <XCTest/XCTest.h>
 #import "TyphoonStartup_Testable.h"

--- a/Tests/Startup/TyphoonStartupTests.m
+++ b/Tests/Startup/TyphoonStartupTests.m
@@ -1,0 +1,51 @@
+//
+//  TyphoonStartupTests.m
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 29/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "TyphoonStartup_Testable.h"
+#import "TyphoonAppDelegateWithInitialFactoryMock.h"
+#import "TyphoonAppDelegateWithInitialAssembliesMock.h"
+#import "TyphoonAppDelegateWithBothMethodsMock.h"
+#import "MiddleAgesAssembly.h"
+
+@interface TyphoonStartupTests : XCTestCase
+
+@end
+
+@implementation TyphoonStartupTests
+
+- (void)test_factory_from_initial_factory_method
+{
+    TyphoonAppDelegateWithInitialFactoryMock *appDelegate = [TyphoonAppDelegateWithInitialFactoryMock new];
+    
+    id factory = [TyphoonStartup factoryFromAppDelegate:appDelegate];
+    
+    XCTAssertNotNil(factory);
+}
+
+- (void)test_factory_from_initial_assemblies_method
+{
+    TyphoonAppDelegateWithInitialAssembliesMock *appDelegate = [TyphoonAppDelegateWithInitialAssembliesMock new];
+    
+    id factory = [TyphoonStartup factoryFromAppDelegate:appDelegate];
+    
+    XCTAssertNotNil(factory);
+}
+
+- (void)test_nitial_assemblies_method_is_preferred
+{
+    TyphoonAppDelegateWithBothMethodsMock *appDelegate = [TyphoonAppDelegateWithBothMethodsMock new];
+    
+    id factory = [TyphoonStartup factoryFromAppDelegate:appDelegate];
+    id knight = [factory knight];
+    
+    XCTAssertNotNil(factory);
+    XCTAssertNotNil(knight);
+}
+
+@end

--- a/Tests/Startup/TyphoonStartup_Testable.h
+++ b/Tests/Startup/TyphoonStartup_Testable.h
@@ -1,0 +1,17 @@
+//
+//  TyphoonStartup_Testable.h
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 29/08/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import "TyphoonStartup.h"
+
+@class TyphoonComponentFactory;
+
+@interface TyphoonStartup ()
+
++ (TyphoonComponentFactory *)factoryFromAppDelegate:(id)appDelegate;
+
+@end

--- a/Tests/Startup/TyphoonStartup_Testable.h
+++ b/Tests/Startup/TyphoonStartup_Testable.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonStartup_Testable.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Egor Tolstoy on 29/08/15.
-//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "TyphoonStartup.h"
 

--- a/Tests/Utils/TyphoonSwizzlerTests.m
+++ b/Tests/Utils/TyphoonSwizzlerTests.m
@@ -43,6 +43,16 @@
         @"Can't swizzle methods since selector foo and bar not implemented in TyphoonSwizzlerTests");
 }
 
+- (void)test_swizzles_when_origin_method_not_exist
+{
+    NSError *error = nil;
+    
+    [_swizzler swizzleMethod:@selector(foo) withMethod:@selector(methodC) onClass:[self class] error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertThrows([self methodC]);
+}
+
 - (NSString *)methodA
 {
     return @"MethodA";
@@ -51,6 +61,11 @@
 - (NSString *)methodB
 {
     return @"MethodB";
+}
+
+- (NSString *)methodC
+{
+    return @"MethodC";
 }
 
 @end

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -518,6 +518,13 @@
 		90ABC4CA1A36BA53008D8162 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 90ABC4C81A36BA53008D8162 /* LaunchScreen.xib */; };
 		90ABC4D61A36BA53008D8162 /* TyphoonFrameworkSwiftExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90ABC4D51A36BA53008D8162 /* TyphoonFrameworkSwiftExampleTests.swift */; };
 		90ABC4E21A36BAE5008D8162 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90ABC4E11A36BAE5008D8162 /* Assembly.swift */; };
+		9F07E41A1B925218007F40F4 /* TyphoonStartupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F07E4191B925218007F40F4 /* TyphoonStartupTests.m */; };
+		9F08355D1B9256EE00866935 /* TyphoonAppDelegateWithInitialFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FEACF391B925657006092EF /* TyphoonAppDelegateWithInitialFactoryMock.m */; };
+		9F08355E1B9256EE00866935 /* TyphoonAppDelegateWithInitialFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FEACF391B925657006092EF /* TyphoonAppDelegateWithInitialFactoryMock.m */; };
+		9F08355F1B9256F100866935 /* TyphoonAppDelegateWithInitialAssembliesMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FEACF3C1B925665006092EF /* TyphoonAppDelegateWithInitialAssembliesMock.m */; };
+		9F0835601B9256F200866935 /* TyphoonAppDelegateWithInitialAssembliesMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FEACF3C1B925665006092EF /* TyphoonAppDelegateWithInitialAssembliesMock.m */; };
+		9F0835611B92583E00866935 /* TyphoonAppDelegateWithBothMethodsMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8990541B92578300C3829A /* TyphoonAppDelegateWithBothMethodsMock.m */; };
+		9F0835621B92583F00866935 /* TyphoonAppDelegateWithBothMethodsMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8990541B92578300C3829A /* TyphoonAppDelegateWithBothMethodsMock.m */; };
 		9F50B2251B80A80A0066BBA1 /* TyphoonAssemblyBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F50B2241B80A80A0066BBA1 /* TyphoonAssemblyBuilderTests.m */; };
 		9F5D32271B872D880023C474 /* TyphoonBundledImageTypeConverterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5D32261B872D880023C474 /* TyphoonBundledImageTypeConverterTests.m */; };
 		9F7522351B80A16A00AE6219 /* TyphoonAssemblyBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F7522341B80A16A00AE6219 /* TyphoonAssemblyBuilder.m */; };
@@ -1064,6 +1071,8 @@
 		90ABC4D41A36BA53008D8162 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		90ABC4D51A36BA53008D8162 /* TyphoonFrameworkSwiftExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TyphoonFrameworkSwiftExampleTests.swift; sourceTree = "<group>"; };
 		90ABC4E11A36BAE5008D8162 /* Assembly.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assembly.swift; sourceTree = "<group>"; };
+		9F07E4191B925218007F40F4 /* TyphoonStartupTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonStartupTests.m; path = Startup/TyphoonStartupTests.m; sourceTree = "<group>"; };
+		9F07E41C1B92526C007F40F4 /* TyphoonStartup_Testable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonStartup_Testable.h; path = Startup/TyphoonStartup_Testable.h; sourceTree = "<group>"; };
 		9F50B2241B80A80A0066BBA1 /* TyphoonAssemblyBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonAssemblyBuilderTests.m; sourceTree = "<group>"; };
 		9F5D32261B872D880023C474 /* TyphoonBundledImageTypeConverterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonBundledImageTypeConverterTests.m; sourceTree = "<group>"; };
 		9F7522331B80A16A00AE6219 /* TyphoonAssemblyBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonAssemblyBuilder.h; sourceTree = "<group>"; };
@@ -1072,6 +1081,12 @@
 		9F7522371B80A25900AE6219 /* TyphoonAssemblyBuilder+PlistProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TyphoonAssemblyBuilder+PlistProcessor.m"; sourceTree = "<group>"; };
 		9F766B6C1B512A66005FC561 /* DecoratedQuest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DecoratedQuest.h; sourceTree = "<group>"; };
 		9F766B6D1B512A66005FC561 /* DecoratedQuest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DecoratedQuest.m; sourceTree = "<group>"; };
+		9F8990531B92578300C3829A /* TyphoonAppDelegateWithBothMethodsMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonAppDelegateWithBothMethodsMock.h; path = Startup/TyphoonAppDelegateWithBothMethodsMock.h; sourceTree = "<group>"; };
+		9F8990541B92578300C3829A /* TyphoonAppDelegateWithBothMethodsMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonAppDelegateWithBothMethodsMock.m; path = Startup/TyphoonAppDelegateWithBothMethodsMock.m; sourceTree = "<group>"; };
+		9FEACF381B925657006092EF /* TyphoonAppDelegateWithInitialFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonAppDelegateWithInitialFactoryMock.h; path = Startup/TyphoonAppDelegateWithInitialFactoryMock.h; sourceTree = "<group>"; };
+		9FEACF391B925657006092EF /* TyphoonAppDelegateWithInitialFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonAppDelegateWithInitialFactoryMock.m; path = Startup/TyphoonAppDelegateWithInitialFactoryMock.m; sourceTree = "<group>"; };
+		9FEACF3B1B925665006092EF /* TyphoonAppDelegateWithInitialAssembliesMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonAppDelegateWithInitialAssembliesMock.h; path = Startup/TyphoonAppDelegateWithInitialAssembliesMock.h; sourceTree = "<group>"; };
+		9FEACF3C1B925665006092EF /* TyphoonAppDelegateWithInitialAssembliesMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonAppDelegateWithInitialAssembliesMock.m; path = Startup/TyphoonAppDelegateWithInitialAssembliesMock.m; sourceTree = "<group>"; };
 		A56819151AA94E6200ECC4F9 /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = "<group>"; };
 		A56819161AA951DE00ECC4F9 /* PrefixTests.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefixTests.pch; sourceTree = "<group>"; };
 		BA79802001176CAE1C666D5B /* TyphoonAssemblyActivator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonAssemblyActivator.h; sourceTree = "<group>"; };
@@ -1770,6 +1785,7 @@
 				6B07707D1936F63A0083714E /* Tests-Info.plist */,
 				6B07707E1936F63A0083714E /* TypeConversion */,
 				6B0770881936F63A0083714E /* Utils */,
+				9F07E41B1B92521C007F40F4 /* Startup */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -2273,6 +2289,21 @@
 				90ABC4D41A36BA53008D8162 /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		9F07E41B1B92521C007F40F4 /* Startup */ = {
+			isa = PBXGroup;
+			children = (
+				9F07E4191B925218007F40F4 /* TyphoonStartupTests.m */,
+				9F07E41C1B92526C007F40F4 /* TyphoonStartup_Testable.h */,
+				9FEACF381B925657006092EF /* TyphoonAppDelegateWithInitialFactoryMock.h */,
+				9FEACF391B925657006092EF /* TyphoonAppDelegateWithInitialFactoryMock.m */,
+				9FEACF3B1B925665006092EF /* TyphoonAppDelegateWithInitialAssembliesMock.h */,
+				9FEACF3C1B925665006092EF /* TyphoonAppDelegateWithInitialAssembliesMock.m */,
+				9F8990531B92578300C3829A /* TyphoonAppDelegateWithBothMethodsMock.h */,
+				9F8990541B92578300C3829A /* TyphoonAppDelegateWithBothMethodsMock.m */,
+			);
+			name = Startup;
 			sourceTree = "<group>";
 		};
 		BA79834647616DAEFF6DBE0F /* Storyboard */ = {
@@ -2893,6 +2924,8 @@
 				6B0771211936FEA80083714E /* PrimitiveMan.m in Sources */,
 				6B0771221936FEA80083714E /* TyphoonComponentDefinition+InstanceBuilderTests.m in Sources */,
 				6B0771341936FEA80083714E /* TyphoonComponentFactoryTests.m in Sources */,
+				9F07E41A1B925218007F40F4 /* TyphoonStartupTests.m in Sources */,
+				9F08355D1B9256EE00866935 /* TyphoonAppDelegateWithInitialFactoryMock.m in Sources */,
 				6B0771351936FEA80083714E /* TyphoonScopeTests.m in Sources */,
 				9F5D32271B872D880023C474 /* TyphoonBundledImageTypeConverterTests.m in Sources */,
 				6B0771361936FEA80083714E /* TyphoonWeakComponentsPoolTests.m in Sources */,
@@ -2932,7 +2965,9 @@
 				6B07715A1936FEA80083714E /* TyphoonTypeConverterRegistryTests.m in Sources */,
 				6B07715B1936FEA80083714E /* TyphoonTypeDescriptorTests.m in Sources */,
 				6B07715D1936FEA80083714E /* TyphoonInvocationUtilsTestObjects.m in Sources */,
+				9F0835611B92583E00866935 /* TyphoonAppDelegateWithBothMethodsMock.m in Sources */,
 				6B07715E1936FEA80083714E /* TyphoonInvocationUtilsTests.m in Sources */,
+				9F08355F1B9256F100866935 /* TyphoonAppDelegateWithInitialAssembliesMock.m in Sources */,
 				6B0771601936FEA80083714E /* TyphoonObjectDeallocCallbackTests.m in Sources */,
 				6B0771611936FEA80083714E /* TyphoonStringUtilsTests.m in Sources */,
 				6B0771621936FEA80083714E /* TyphoonMethodSwizzlerTestUtils.m in Sources */,
@@ -3160,13 +3195,16 @@
 				BA798897E9BC1EA32CEBF96F /* InvalidCollaboratingAssembly_Initializer.m in Sources */,
 				BA7981D5BBCDA4034801A3A4 /* TyphoonAssemblySelectorAdviserTests.m in Sources */,
 				BA798DA086CE35B97D79C17E /* TyphoonAssemblyExtendTests.m in Sources */,
+				9F0835601B9256F200866935 /* TyphoonAppDelegateWithInitialAssembliesMock.m in Sources */,
 				BA798266CB7E54CD795C4E16 /* TyphoonCollaboratingAssemblyPropertyEnumeratorTests.m in Sources */,
 				BA798A98C3FB98E74374C426 /* TyphoonAssemblyAdviserTests.m in Sources */,
 				BA79898188598B8C8C2BF6AB /* TyphoonCollaboratingAssemblyPropertyEnumeratorTests_AssemblyWithProperty.m in Sources */,
+				9F08355E1B9256EE00866935 /* TyphoonAppDelegateWithInitialFactoryMock.m in Sources */,
 				BA798C0A66B2ADE4D954B12D /* TyphoonFactoryDefinitionTests.m in Sources */,
 				BA7983AE20677ACE9899931E /* TyphoonAssemblyTests.m in Sources */,
 				BA79818957F523EAE1CF4377 /* TyphoonSwizzlerTests.m in Sources */,
 				BA798E8723BBEBAC341F417C /* ConfigAssembly.m in Sources */,
+				9F0835621B92583F00866935 /* TyphoonAppDelegateWithBothMethodsMock.m in Sources */,
 				BA79882D38511D046307E700 /* TyphoonStartupTests_OSX.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Besides some unit tests, fixed the ability to use object subscription syntax with `TyphoonComponentFactory` and `TyphoonAssembly`:

```objc
_factory[@"knight"];
_assembly[[Knight class]];
```