### PR TITLE
Fix Typhoon.framework target

### DIFF
--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		2DBA1F22197B2F62174AC928 /* TyphoonNemoTestAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA10314E7114955C0AB31E /* TyphoonNemoTestAssemblies.m */; };
 		2DBA1FB1F6532DA96182BD13 /* TyphoonTestAssemblyConfigPostProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA14D1F4E06EDCD57873A2 /* TyphoonTestAssemblyConfigPostProcessor.m */; };
 		2DBA1FC0E15A415D0297317B /* AutoInjectionKnight.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA18F5476952207F6E2B0D /* AutoInjectionKnight.m */; };
+		3BB1324F1BA0577600823798 /* TyphoonInjectionDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1851EF633B38D4C7866A /* TyphoonInjectionDefinition.m */; };
 		6B076E5E1936F5850083714E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B076E5D1936F5850083714E /* Foundation.framework */; };
 		6B076E601936F5850083714E /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B076E5F1936F5850083714E /* CoreGraphics.framework */; };
 		6B076E621936F5850083714E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B076E611936F5850083714E /* UIKit.framework */; };
@@ -3236,6 +3237,7 @@
 				90ABC40B1A36B1B4008D8162 /* TyphoonBundleResource.m in Sources */,
 				90ABC40C1A36B1B4008D8162 /* TyphoonPathResource.m in Sources */,
 				90ABC40D1A36B1B4008D8162 /* TyphoonAbstractDetachableComponentFactoryPostProcessor.m in Sources */,
+				3BB1324F1BA0577600823798 /* TyphoonInjectionDefinition.m in Sources */,
 				90ABC40E1A36B1B4008D8162 /* TyphoonStartup.m in Sources */,
 				90ABC40F1A36B1B4008D8162 /* TyphoonAbstractInjection.m in Sources */,
 				90ABC4101A36B1B4008D8162 /* TyphoonInjectionByCollection.m in Sources */,

--- a/build.sh
+++ b/build.sh
@@ -36,12 +36,14 @@ git submodule update
 ditto ${resourceDir}/build-failed.png ${reportsDir}/build-status/build-status.png
 
 
-#Compile, run tests and produce coverage report for iOS Simulator
+#Build framework
 platform=iOS_Simulator
-mkdir -p ${reportsDir}/${platform}
-
-
 rm -fr ~/Library/Developer/Xcode/DerivedData
+
+xcodebuild -project Typhoon.xcodeproj/ -scheme 'Typhoon' clean build | xcpretty -c
+
+#Run tests and produce coverage report for iOS Simulator
+mkdir -p ${reportsDir}/${platform}
 xcodebuild test -project Typhoon.xcodeproj -scheme 'Typhoon-iOSTests' -configuration Debug \
 -destination 'platform=iOS Simulator,name=iPhone 5s,OS=8.4' | xcpretty -c --report junit
 mv ${reportsDir}/junit.xml ${reportsDir}/${platform}/junit.xml


### PR DESCRIPTION
Issue: https://github.com/appsquickly/Typhoon/issues/411

Typhoon.framework target is broken because TyphoonInjectionDefinition is missing from the framework target. 

This PR adds this class to the target. 

I also extended the build.sh to build Typhoon.framework as well so these kind of issues will surface quickly.  
