### PR TITLE
Multiple storyboards support

### DIFF
--- a/Source/ios/Storyboard/TyphoonStoryboardProvider.h
+++ b/Source/ios/Storyboard/TyphoonStoryboardProvider.h
@@ -1,0 +1,18 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonStoryboardProvider : NSObject
+
+- (NSArray *)collectStoryboardsFromBundle:(NSBundle *)bundle;
+
+@end

--- a/Source/ios/Storyboard/TyphoonStoryboardProvider.m
+++ b/Source/ios/Storyboard/TyphoonStoryboardProvider.m
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonStoryboardProvider.h"
+
+#import "OCLogTemplate.h"
+
+@implementation TyphoonStoryboardProvider
+
+- (NSArray *)collectStoryboardsFromBundle:(NSBundle *)bundle {
+    NSArray *storyboardPaths = [bundle pathsForResourcesOfType:@"storyboardc"
+                                                   inDirectory:@""];
+    
+    NSMutableSet *mutableStoryboardNames = [NSMutableSet new];
+    for (NSString *storyboardPath in storyboardPaths) {
+        NSString *storyboardName = [[storyboardPath lastPathComponent] stringByDeletingPathExtension];
+        [mutableStoryboardNames addObject:storyboardName];
+    }
+    NSSet *storyboardNames = [mutableStoryboardNames copy];
+    
+    storyboardNames = [self filterStoryboards:storyboardNames
+                        withBlackListInBundle:bundle];
+    
+    return [storyboardNames allObjects];
+}
+
+- (NSSet *)filterStoryboards:(NSSet *)storyboardNames withBlackListInBundle:(NSBundle *)bundle {
+    NSDictionary *bundleInfoDictionary = [bundle infoDictionary];
+    NSSet *blackListedNames = [NSSet setWithArray:bundleInfoDictionary[@"TyphoonCleanStoryboards"]];
+    
+    for (NSString *blackListedName in blackListedNames) {
+        if (![storyboardNames containsObject:blackListedName]) {
+            LogInfo(@"*** Warning *** Can't find black-listed storyboard with name %@. Is this intentional?", blackListedName);
+        }
+    }
+    
+    NSMutableSet *filteredStoryboardNames = [storyboardNames mutableCopy];
+    [filteredStoryboardNames minusSet:blackListedNames];
+    
+    return [filteredStoryboardNames copy];
+}
+
+@end

--- a/Source/ios/Storyboard/TyphoonStoryboardResolver.h
+++ b/Source/ios/Storyboard/TyphoonStoryboardResolver.h
@@ -13,5 +13,5 @@
 #import <Foundation/Foundation.h>
 
 
-@interface TyphoonInitialStoryboardResolver : NSObject
+@interface TyphoonStoryboardResolver : NSObject
 @end

--- a/Tests/iOS/StoryboardProvider/TyphoonStoryboardProviderTests.m
+++ b/Tests/iOS/StoryboardProvider/TyphoonStoryboardProviderTests.m
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <XCTest/XCTest.h>
+#import <OCMockitoIOS/OCMockitoIOS.h>
+
+#import "TyphoonStoryboardProvider.h"
+
+@interface TyphoonStoryboardProviderTests : XCTestCase
+
+@property (strong, nonatomic) TyphoonStoryboardProvider *provider;
+@property (strong, nonatomic) NSBundle *testBundle;
+
+@end
+
+@implementation TyphoonStoryboardProviderTests
+
+- (void)setUp {
+    [super setUp];
+    
+    self.provider = [TyphoonStoryboardProvider new];
+    
+    self.testBundle = MKTMock([NSBundle class]);
+    NSArray *testStoryboardsPaths = @[
+                                      @"/Users/etolstoy/Library/Developer/CoreSimulator/Devices/2FCF21A0-E58A-4E87-BC8C-D63B33CEF2B8/data/Containers/Bundle/Application/68288B52-6B1F-4260-B817-23A90E320A5F/Typhoon-iOS.app/Storyboard1.storyboardc",
+                                      @"/Users/etolstoy/Library/Developer/CoreSimulator/Devices/2FCF21A0-E58A-4E87-BC8C-D63B33CEF2B8/data/Containers/Bundle/Application/68288B52-6B1F-4260-B817-23A90E320A5F/Typhoon-iOS.app/Base.lproj/Storyboard2.storyboardc"
+                                      ];
+    [given([self.testBundle pathsForResourcesOfType:@"storyboardc" inDirectory:@""]) willReturn:testStoryboardsPaths];
+    
+}
+
+- (void)tearDown {
+    self.provider = nil;
+    self.testBundle = nil;
+    
+    [super tearDown];
+}
+
+- (void)test_provider_returns_all_storyboards_in_bundle
+{
+    NSArray *expectedStoryboardNames = @[@"Storyboard1", @"Storyboard2"];
+    
+    NSArray *result = [self.provider collectStoryboardsFromBundle:self.testBundle];
+    
+    XCTAssertEqual(result.count, expectedStoryboardNames.count);
+    
+    for (NSString *resultName in result) {
+        NSUInteger index = [result indexOfObject:resultName];
+        XCTAssertEqualObjects(resultName, expectedStoryboardNames[index]);
+    }
+}
+
+- (void)test_provider_filters_storyboards_with_black_list
+{
+    NSDictionary *testBundleInfo = @{
+                                     @"TyphoonCleanStoryboards" : @[@"Storyboard1"]
+                                     };
+    NSArray *expectedStoryboardNames = @[@"Storyboard2"];
+    
+    [given([self.testBundle infoDictionary]) willReturn:testBundleInfo];
+    
+    NSArray *result = [self.provider collectStoryboardsFromBundle:self.testBundle];
+    
+    XCTAssertEqual(result.count, expectedStoryboardNames.count);
+    
+    for (NSString *resultName in result) {
+        NSUInteger index = [result indexOfObject:resultName];
+        XCTAssertEqualObjects(resultName, expectedStoryboardNames[index]);
+    }
+}
+
+@end

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		2DBA19726EA475E685E8687E /* TyphoonFactoryDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA13E1E8F0928568F42BE0 /* TyphoonFactoryDefinition.m */; };
 		2DBA19D13EB2E1F96130F61A /* TyphoonAutoInjectionAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA198A0174DBC7F1A60761 /* TyphoonAutoInjectionAssembly.m */; };
 		2DBA19D30BC89B0BFA82C081 /* TyphoonOptionMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA102EFAD54C22C82B4834 /* TyphoonOptionMatcher.m */; };
-		2DBA19F9B65EE9FB8DBF13EA /* TyphoonInitialStoryboardResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1F19AACBE84474E823C4 /* TyphoonInitialStoryboardResolver.m */; };
+		2DBA19F9B65EE9FB8DBF13EA /* TyphoonStoryboardResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1F19AACBE84474E823C4 /* TyphoonStoryboardResolver.m */; };
 		2DBA1A73D490C68DEE37DB24 /* TyphoonNemoTestAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA10314E7114955C0AB31E /* TyphoonNemoTestAssemblies.m */; };
 		2DBA1AA360C59D1F3360E7F6 /* TyphoonFactoryAutoInjectionPostProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1C5E0FDB03006A2223F8 /* TyphoonFactoryAutoInjectionPostProcessor.m */; };
 		2DBA1BD2F98EAF82D31B9876 /* TyphoonInjectedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1899426943444774AC27 /* TyphoonInjectedObject.m */; };
@@ -406,7 +406,7 @@
 		90ABC43D1A36B1B4008D8162 /* TyphoonDefinitionRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F4B1936F63A0083714E /* TyphoonDefinitionRegisterer.m */; };
 		90ABC43E1A36B1B4008D8162 /* TyphoonViewControllerNibResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F501936F63A0083714E /* TyphoonViewControllerNibResolver.m */; };
 		90ABC43F1A36B1B4008D8162 /* TyphoonStoryboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F531936F63A0083714E /* TyphoonStoryboard.m */; };
-		90ABC4401A36B1B4008D8162 /* TyphoonInitialStoryboardResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1F19AACBE84474E823C4 /* TyphoonInitialStoryboardResolver.m */; };
+		90ABC4401A36B1B4008D8162 /* TyphoonStoryboardResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1F19AACBE84474E823C4 /* TyphoonStoryboardResolver.m */; };
 		90ABC4411A36B1B4008D8162 /* TyphoonBundledImageTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F571936F63A0083714E /* TyphoonBundledImageTypeConverter.m */; };
 		90ABC4421A36B1B4008D8162 /* TyphoonUIColorTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F591936F63A0083714E /* TyphoonUIColorTypeConverter.m */; };
 		90ABC4431A36B1B4008D8162 /* TyphoonPatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F601936F63A0083714E /* TyphoonPatcher.m */; };
@@ -490,7 +490,7 @@
 		90ABC49A1A36B2A1008D8162 /* TyphoonDefinitionRegisterer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F4A1936F63A0083714E /* TyphoonDefinitionRegisterer.h */; };
 		90ABC49B1A36B2A1008D8162 /* TyphoonViewControllerNibResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F4F1936F63A0083714E /* TyphoonViewControllerNibResolver.h */; };
 		90ABC49C1A36B2A1008D8162 /* TyphoonStoryboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F521936F63A0083714E /* TyphoonStoryboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90ABC49D1A36B2A1008D8162 /* TyphoonInitialStoryboardResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA129FBD11BA18D318694D /* TyphoonInitialStoryboardResolver.h */; };
+		90ABC49D1A36B2A1008D8162 /* TyphoonStoryboardResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA129FBD11BA18D318694D /* TyphoonStoryboardResolver.h */; };
 		90ABC49E1A36B2A1008D8162 /* TyphoonBundledImageTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F561936F63A0083714E /* TyphoonBundledImageTypeConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90ABC49F1A36B2A1008D8162 /* TyphoonUIColorTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F581936F63A0083714E /* TyphoonUIColorTypeConverter.h */; };
 		90ABC4A01A36B2A2008D8162 /* TyphooniOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F5A1936F63A0083714E /* TyphooniOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -539,6 +539,8 @@
 		9F65CEEB1BA1559E0015765B /* DecoratedQuest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F65CEE81BA1559A0015765B /* DecoratedQuest.m */; };
 		9F98B2E81BA0BF5D00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */; };
 		9F98B2EB1BA0BF5E00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */; };
+		9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; };
+		9FDF58D11BA4168100678B2B /* TyphoonStoryboardProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */; };
 		A5522B801AAA8C9500B93CD9 /* TyphoonPatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F601936F63A0083714E /* TyphoonPatcher.m */; };
 		A56819061AA9403000ECC4F9 /* TyphoonAssemblyActivator.h in Headers */ = {isa = PBXBuildFile; fileRef = BA79802001176CAE1C666D5B /* TyphoonAssemblyActivator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A56819081AA9462F00ECC4F9 /* Typhoon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90ABC3EA1A36B09E008D8162 /* Typhoon.framework */; };
@@ -719,7 +721,7 @@
 		2DBA102EFAD54C22C82B4834 /* TyphoonOptionMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonOptionMatcher.m; sourceTree = "<group>"; };
 		2DBA10314E7114955C0AB31E /* TyphoonNemoTestAssemblies.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonNemoTestAssemblies.m; sourceTree = "<group>"; };
 		2DBA116C73989B40B232BA11 /* TyphoonAutoInjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonAutoInjection.h; sourceTree = "<group>"; };
-		2DBA129FBD11BA18D318694D /* TyphoonInitialStoryboardResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonInitialStoryboardResolver.h; sourceTree = "<group>"; };
+		2DBA129FBD11BA18D318694D /* TyphoonStoryboardResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonStoryboardResolver.h; sourceTree = "<group>"; };
 		2DBA13E1E8F0928568F42BE0 /* TyphoonFactoryDefinition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonFactoryDefinition.m; sourceTree = "<group>"; };
 		2DBA1463AEC1B97752A6DF8C /* TyphoonInjectionDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonInjectionDefinition.h; sourceTree = "<group>"; };
 		2DBA14D1F4E06EDCD57873A2 /* TyphoonTestAssemblyConfigPostProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonTestAssemblyConfigPostProcessor.m; sourceTree = "<group>"; };
@@ -740,7 +742,7 @@
 		2DBA1C60F38237F082D0E64A /* AutoWiringKnight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoWiringKnight.m; sourceTree = "<group>"; };
 		2DBA1D75E5069184DF749775 /* TyphoonLoadedView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLoadedView.m; sourceTree = "<group>"; };
 		2DBA1E968487D687338D5E0F /* TyphoonNemoTestAssemblies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonNemoTestAssemblies.h; sourceTree = "<group>"; };
-		2DBA1F19AACBE84474E823C4 /* TyphoonInitialStoryboardResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonInitialStoryboardResolver.m; sourceTree = "<group>"; };
+		2DBA1F19AACBE84474E823C4 /* TyphoonStoryboardResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonStoryboardResolver.m; sourceTree = "<group>"; };
 		2DBA1F7A42D15F175F25EF57 /* TyphoonLoadedView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonLoadedView.h; sourceTree = "<group>"; };
 		2DBA1FB2212B952164C02878 /* TyphoonFactoryDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonFactoryDefinition.h; sourceTree = "<group>"; };
 		2DBA1FC6F594C49C7D8261A6 /* TyphoonInjections.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonInjections.m; sourceTree = "<group>"; };
@@ -1089,6 +1091,9 @@
 		9F7522371B80A25900AE6219 /* TyphoonAssemblyBuilder+PlistProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TyphoonAssemblyBuilder+PlistProcessor.m"; sourceTree = "<group>"; };
 		9F98B2DF1BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonLoopedCollaboratingAssemblies.h; sourceTree = "<group>"; };
 		9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLoopedCollaboratingAssemblies.m; sourceTree = "<group>"; };
+		9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonStoryboardProvider.h; sourceTree = "<group>"; };
+		9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonStoryboardProvider.m; sourceTree = "<group>"; };
+		9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonStoryboardProviderTests.m; path = StoryboardProvider/TyphoonStoryboardProviderTests.m; sourceTree = "<group>"; };
 		9FFB52551BA152FF0078F6B2 /* TyphoonSingleAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonSingleAssembly.h; sourceTree = "<group>"; };
 		9FFB52561BA152FF0078F6B2 /* TyphoonSingleAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonSingleAssembly.m; sourceTree = "<group>"; };
 		A56819151AA94E6200ECC4F9 /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = "<group>"; };
@@ -1635,12 +1640,14 @@
 			children = (
 				6B076F521936F63A0083714E /* TyphoonStoryboard.h */,
 				6B076F531936F63A0083714E /* TyphoonStoryboard.m */,
-				2DBA1F19AACBE84474E823C4 /* TyphoonInitialStoryboardResolver.m */,
-				2DBA129FBD11BA18D318694D /* TyphoonInitialStoryboardResolver.h */,
+				2DBA1F19AACBE84474E823C4 /* TyphoonStoryboardResolver.m */,
+				2DBA129FBD11BA18D318694D /* TyphoonStoryboardResolver.h */,
 				2DBA1D75E5069184DF749775 /* TyphoonLoadedView.m */,
 				2DBA1F7A42D15F175F25EF57 /* TyphoonLoadedView.h */,
 				8946F2DE1B8E403E005C4954 /* TyphoonViewHelpers.h */,
 				8946F2DF1B8E403E005C4954 /* TyphoonViewHelpers.m */,
+				9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */,
+				9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */,
 			);
 			path = Storyboard;
 			sourceTree = "<group>";
@@ -1995,6 +2002,7 @@
 				6B0770251936F63A0083714E /* Typhoon-iOSTests */,
 				BA7984A17357C335F57B7C8F /* TypeConversion */,
 				BA798A2D49CA1A87BBAE458A /* Resolver */,
+				9FDF58CF1BA4165700678B2B /* StoryboardProvider */,
 				BA79834647616DAEFF6DBE0F /* Storyboard */,
 			);
 			path = iOS;
@@ -2311,6 +2319,14 @@
 			name = Startup;
 			sourceTree = "<group>";
 		};
+		9FDF58CF1BA4165700678B2B /* StoryboardProvider */ = {
+			isa = PBXGroup;
+			children = (
+				9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */,
+			);
+			name = StoryboardProvider;
+			sourceTree = "<group>";
+		};
 		BA79834647616DAEFF6DBE0F /* Storyboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -2456,7 +2472,7 @@
 				90ABC4981A36B2A1008D8162 /* TyphoonWeakComponentsPool.h in Headers */,
 				90ABC49A1A36B2A1008D8162 /* TyphoonDefinitionRegisterer.h in Headers */,
 				90ABC49B1A36B2A1008D8162 /* TyphoonViewControllerNibResolver.h in Headers */,
-				90ABC49D1A36B2A1008D8162 /* TyphoonInitialStoryboardResolver.h in Headers */,
+				90ABC49D1A36B2A1008D8162 /* TyphoonStoryboardResolver.h in Headers */,
 				90ABC49F1A36B2A1008D8162 /* TyphoonUIColorTypeConverter.h in Headers */,
 				90ABC4A11A36B2A2008D8162 /* TyphoonPatcher.h in Headers */,
 				90ABC4A21A36B2A2008D8162 /* TyphoonTestUtils.h in Headers */,
@@ -2821,6 +2837,7 @@
 				6B0770A31936F9000083714E /* TyphoonAbstractInjection.m in Sources */,
 				6B0770A41936F9000083714E /* TyphoonInjectionByCollection.m in Sources */,
 				6B0770A51936F9000083714E /* TyphoonInjectionByComponentFactory.m in Sources */,
+				9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */,
 				6B0770A61936F9000083714E /* TyphoonInjectionByConfig.m in Sources */,
 				6B0770A71936F9000083714E /* TyphoonInjectionByDictionary.m in Sources */,
 				6B0770A81936F9000083714E /* TyphoonInjectionByFactoryReference.m in Sources */,
@@ -2863,7 +2880,7 @@
 				9F65CEE41BA1555D0015765B /* TyphoonAssemblyBuilder+PlistProcessor.m in Sources */,
 				2DBA13020BD1DDD15231B84C /* TyphoonInjections.m in Sources */,
 				2DBA14D07CBAF423D1C4BEA4 /* TyphoonStartup.m in Sources */,
-				2DBA19F9B65EE9FB8DBF13EA /* TyphoonInitialStoryboardResolver.m in Sources */,
+				2DBA19F9B65EE9FB8DBF13EA /* TyphoonStoryboardResolver.m in Sources */,
 				C9497BE0FC290233160074AC /* Mock.m in Sources */,
 				C9497A0F3C744433419C9D5D /* TyphoonInjectionByCurrentRuntimeArguments.m in Sources */,
 				2DBA1BD2F98EAF82D31B9876 /* TyphoonInjectedObject.m in Sources */,
@@ -2960,6 +2977,7 @@
 				6B0771501936FEA80083714E /* MediocreQuest.m in Sources */,
 				6B0771511936FEA80083714E /* NotSingletonA.m in Sources */,
 				6B0771521936FEA80083714E /* SingletonA.m in Sources */,
+				9FDF58D11BA4168100678B2B /* TyphoonStoryboardProviderTests.m in Sources */,
 				6B0771531936FEA80083714E /* SingletonB.m in Sources */,
 				6B0771541936FEA80083714E /* TyphoonPatcherTests.m in Sources */,
 				6B0771551936FEA80083714E /* TyphoonTestUtilsTests.m in Sources */,
@@ -3273,7 +3291,7 @@
 				90ABC43D1A36B1B4008D8162 /* TyphoonDefinitionRegisterer.m in Sources */,
 				90ABC43E1A36B1B4008D8162 /* TyphoonViewControllerNibResolver.m in Sources */,
 				90ABC43F1A36B1B4008D8162 /* TyphoonStoryboard.m in Sources */,
-				90ABC4401A36B1B4008D8162 /* TyphoonInitialStoryboardResolver.m in Sources */,
+				90ABC4401A36B1B4008D8162 /* TyphoonStoryboardResolver.m in Sources */,
 				90ABC4411A36B1B4008D8162 /* TyphoonBundledImageTypeConverter.m in Sources */,
 				90ABC4421A36B1B4008D8162 /* TyphoonUIColorTypeConverter.m in Sources */,
 				90ABC4431A36B1B4008D8162 /* TyphoonPatcher.m in Sources */,


### PR DESCRIPTION
As discussed in Issue #415, I've added the automated activation of all of the storyboards in the main bundle of the application. If a user doesn't want to activate any of the storyboards, he can list it under the `TyphoonCleanStoryboards` key in the `Info.plist` file.

I've tested the behaviour with the referenced storyboards feature - everything is working. Unfortunately I had to remove this test, because to support it we'd have to increase the Deployment Target up to 9.0.

After merging I'll add the corresponding information to the wiki.