### PR TITLE
Remove use of reserved keyboard in public header

### DIFF
--- a/Source/Factory/Internal/TyphoonAssemblyAdviser.h
+++ b/Source/Factory/Internal/TyphoonAssemblyAdviser.h
@@ -18,7 +18,7 @@
 
 @interface TyphoonAssemblyAdviser : NSObject
 
-+ (BOOL)assemblyClassIsAdvised:(Class)class;
++ (BOOL)assemblyClassIsAdvised:(Class)klass;
 
 - (id)initWithAssembly:(TyphoonAssembly *)assembly;
 


### PR DESCRIPTION
Hi all,

Just a tiny one - currently trying to build our project with dynamic frameworks, and importing the umbrella header for Cocoapods. Small error here because `class` is used as a method parameter, and C++ isn't as tolerant of this an ObjC.

Thanks!