### PR TITLE
TyphoonClassFromString performance optimization

### DIFF
--- a/Source/Utils/TyphoonIntrospectionUtils.m
+++ b/Source/Utils/TyphoonIntrospectionUtils.m
@@ -302,6 +302,12 @@ Class TyphoonClassFromString(NSString *className)
         the name of the module
 
         */
+        
+        //Those class names will never be resolved, so no reason to try
+        if(!className || [className isEqual:@"?"] || [className isEqual:@""]) {
+            return nil;
+        }
+        
         NSArray *frameworks = [NSBundle allFrameworks];
         for (uint i = 0; i < frameworks.count && clazz == nil; ++i) {
             NSBundle *framework = [frameworks objectAtIndex:i];


### PR DESCRIPTION
Iterating over [NSBundle allFrameworks] every time is expensive, so this should ease the pain.