### PR TITLE
Added the ability to turn logging on/off in the runtime

### DIFF
--- a/Source/Configuration/ConfigPostProcessor/TyphoonConfigPostProcessor.m
+++ b/Source/Configuration/ConfigPostProcessor/TyphoonConfigPostProcessor.m
@@ -127,9 +127,6 @@ static NSMutableDictionary *propertyPlaceholderRegistry;
 
 - (void)useResource:(id<TyphoonResource>)resource withExtension:(NSString *)typeExtension
 {
-    LogInfo("======================================================================================================");
-    LogInfo(@"CONFIG: %@", resource.description);
-    LogInfo("======================================================================================================");
     id<TyphoonConfiguration> config = _configs[typeExtension];
     [config appendResource:resource];
 }

--- a/Source/Typhoon.h
+++ b/Source/Typhoon.h
@@ -40,6 +40,8 @@ FOUNDATION_EXPORT const unsigned char TyphoonVersionString[];
 
 #import "TyphoonAutoInjection.h"
 
+#import "TyphoonLogging.h"
+
 #if TARGET_OS_IPHONE
 #import "TyphooniOS.h"
 #endif

--- a/Source/Utils/TyphoonLogging.h
+++ b/Source/Utils/TyphoonLogging.h
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonLogging : NSObject
+
+/**
+ Returns current logging state
+ 
+ @return YES - if logging is enabled/NO - of logging is disabled
+ */
++ (BOOL)isLoggingEnabled;
+
+/**
+ Sets logging state - enabled or disabled. Default - YES for debug, NO - for release.
+ */
++ (void)setLoggingEnabled:(BOOL)enabled;
+
+@end

--- a/Source/Utils/TyphoonLogging.m
+++ b/Source/Utils/TyphoonLogging.m
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonLogging.h"
+
+#ifdef DEBUG
+    static BOOL kTyphoonLoggingEnabled = YES;
+#else
+    static BOOL kTyphoonLoggingEnabled = NO;
+#endif
+
+@implementation TyphoonLogging
+
++ (BOOL)isLoggingEnabled {
+    return kTyphoonLoggingEnabled;
+}
+
++ (void)setLoggingEnabled:(BOOL)enabled {
+    kTyphoonLoggingEnabled = enabled;
+}
+
+@end

--- a/Source/Vendor/OCLogTemplate/OCLogTemplate.h
+++ b/Source/Vendor/OCLogTemplate/OCLogTemplate.h
@@ -94,8 +94,24 @@
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 
 // Logging format
-#define LOG_FORMAT_NO_LOCATION(fmt, lvl, ...) NSLog((@"[%@] " fmt), lvl, ##__VA_ARGS__)
-#define LOG_FORMAT_WITH_LOCATION(fmt, lvl, ...) NSLog((@"%s[Line %d] [%@] " fmt), __PRETTY_FUNCTION__, __LINE__, lvl, ##__VA_ARGS__)
+#import "TyphoonLogging.h"
+#define LOG_FORMAT_NO_LOCATION(fmt, lvl, ...)             \
+do                                                        \
+{                                                         \
+    if ([TyphoonLogging isLoggingEnabled] == YES)         \
+    {                                                     \
+        NSLog((@"[%@] " fmt), lvl, ##__VA_ARGS__)         \
+    }                                                     \
+} while (0)
+
+#define LOG_FORMAT_WITH_LOCATION(fmt, lvl, ...)           \
+do                                                        \
+{                                                         \
+    if ([TyphoonLogging isLoggingEnabled] == YES)         \
+    {                                                     \
+        NSLog((@"%s[Line %d] [%@] " fmt), __PRETTY_FUNCTION__, __LINE__, lvl, ##__VA_ARGS__);\
+    }                                                     \
+} while (0)
 
 #if defined(LOGGING_INCLUDE_CODE_LOCATION) && LOGGING_INCLUDE_CODE_LOCATION
 #define LOG_FORMAT(fmt, lvl, ...) LOG_FORMAT_WITH_LOCATION(fmt, lvl, ##__VA_ARGS__)

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 		9F65CEEB1BA1559E0015765B /* DecoratedQuest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F65CEE81BA1559A0015765B /* DecoratedQuest.m */; };
 		9F98B2E81BA0BF5D00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */; };
 		9F98B2EB1BA0BF5E00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */; };
+		9FCE2FD21BD40529003896E6 /* TyphoonLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FCE2FD11BD40529003896E6 /* TyphoonLogging.m */; settings = {ASSET_TAGS = (); }; };
 		9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; };
 		9FDF58D11BA4168100678B2B /* TyphoonStoryboardProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */; };
 		A5522B801AAA8C9500B93CD9 /* TyphoonPatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F601936F63A0083714E /* TyphoonPatcher.m */; };
@@ -1093,6 +1094,8 @@
 		9F7522371B80A25900AE6219 /* TyphoonAssemblyBuilder+PlistProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TyphoonAssemblyBuilder+PlistProcessor.m"; sourceTree = "<group>"; };
 		9F98B2DF1BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonLoopedCollaboratingAssemblies.h; sourceTree = "<group>"; };
 		9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLoopedCollaboratingAssemblies.m; sourceTree = "<group>"; };
+		9FCE2FD01BD40529003896E6 /* TyphoonLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonLogging.h; sourceTree = "<group>"; };
+		9FCE2FD11BD40529003896E6 /* TyphoonLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLogging.m; sourceTree = "<group>"; };
 		9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonStoryboardProvider.h; sourceTree = "<group>"; };
 		9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonStoryboardProvider.m; sourceTree = "<group>"; };
 		9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonStoryboardProviderTests.m; path = StoryboardProvider/TyphoonStoryboardProviderTests.m; sourceTree = "<group>"; };
@@ -1755,6 +1758,8 @@
 				6B076F861936F63A0083714E /* TyphoonLinkerCategoryBugFix.h */,
 				6B076F891936F63A0083714E /* TyphoonSelector.h */,
 				6B076F8A1936F63A0083714E /* TyphoonSelector.m */,
+				9FCE2FD01BD40529003896E6 /* TyphoonLogging.h */,
+				9FCE2FD11BD40529003896E6 /* TyphoonLogging.m */,
 				6B076F8B1936F63A0083714E /* TyphoonUtils.h */,
 			);
 			path = Utils;
@@ -2856,6 +2861,7 @@
 				6B0770B31936F9000083714E /* TyphoonReferenceDefinition.m in Sources */,
 				6B0770B41936F9000083714E /* TyphoonMethod+InstanceBuilder.m in Sources */,
 				6B0770B51936F9000083714E /* TyphoonMethod.m in Sources */,
+				9FCE2FD21BD40529003896E6 /* TyphoonLogging.m in Sources */,
 				6B0770B61936F9000083714E /* TyphoonDefinition.m in Sources */,
 				6B0770B81936F9000083714E /* TyphoonAssembly.m in Sources */,
 				9F65CEE11BA155590015765B /* TyphoonAssemblyBuilder.m in Sources */,
@@ -3549,6 +3555,10 @@
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Source/Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = "Tests/iOS/Typhoon-iOS/Typhoon-iOS-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;


### PR DESCRIPTION
This is a quick-fix for #435 issue. The PR contains the following changes:

- A new class `TyphoonLogging.h` with two methods: `+ (BOOL)isLoggingEnabled` and `+ (void)setLoggingEnabled:(BOOL)enabled`. The second one can be used somewhere before or after Typhoon instantiation process to turn the logging on or off.
- Some changes in the built-in file `OCLogTemplate.h` - it now looks at the state of Typhoon `isLoggingEnabled` method before exact logging.
- Turned off logs in the `TyphoonConfigPostProcessor` - not sure that they were necessary. To turn them off the user had to hook before the Typhoon instantiation - and that's rather inconvenient.

I think of implementing more flexible logging system, with providing the logging levels in the runtime: 
```
+ (void)setLoggingLevel:(TyphoonLoggingLevel)level;
```

Maybe we can even use `Cocoalumberjack` with it, just like `MagicalRecord` does (https://github.com/magicalpanda/MagicalRecord/wiki/Logging).