### PR TITLE
Removed the singletone TyphoonTypeConverterRegistry

### DIFF
--- a/Source/Definition/Injections/TyphoonInjectionByObjectFromString.m
+++ b/Source/Definition/Injections/TyphoonInjectionByObjectFromString.m
@@ -65,7 +65,7 @@
 - (id)convertText:(NSString *)text
 {
     id result = text;
-    NSString *typeString = [TyphoonTypeConverterRegistry typeFromTextValue:text];
+    NSString *typeString = [TyphoonTypeConversionUtils typeFromTextValue:text];
     if (typeString) {
         id <TyphoonTypeConverter> converter = [[TyphoonTypeConverterRegistry shared] converterForType:typeString];
         if (converter) {

--- a/Source/Definition/Injections/TyphoonInjectionByObjectFromString.m
+++ b/Source/Definition/Injections/TyphoonInjectionByObjectFromString.m
@@ -48,26 +48,27 @@
 - (void)valueToInjectWithContext:(TyphoonInjectionContext *)context completion:(TyphoonInjectionValueBlock)result
 {
     TyphoonTypeDescriptor *type = context.destinationType;
+    TyphoonComponentFactory *factory = context.factory;
 
     id value = nil;
     
     if (type.isPrimitive) {
-        TyphoonPrimitiveTypeConverter *converter = [[TyphoonTypeConverterRegistry shared] primitiveTypeConverter];
+        TyphoonPrimitiveTypeConverter *converter = [factory.typeConverterRegistry primitiveTypeConverter];
         value = [converter valueFromText:self.textValue withType:type];
     }
     else {
-        value = [self convertText:self.textValue];
+        value = [self convertText:self.textValue withTypeConverterRegistry:factory.typeConverterRegistry];
     }
     
     result(value);
 }
 
-- (id)convertText:(NSString *)text
+- (id)convertText:(NSString *)text withTypeConverterRegistry:(TyphoonTypeConverterRegistry *)typeConverterRegistry
 {
     id result = text;
     NSString *typeString = [TyphoonTypeConversionUtils typeFromTextValue:text];
     if (typeString) {
-        id <TyphoonTypeConverter> converter = [[TyphoonTypeConverterRegistry shared] converterForType:typeString];
+        id <TyphoonTypeConverter> converter = [typeConverterRegistry converterForType:typeString];
         if (converter) {
             result = [converter convert:text];
         }

--- a/Source/Factory/TyphoonComponentFactory.h
+++ b/Source/Factory/TyphoonComponentFactory.h
@@ -18,6 +18,7 @@
 @class TyphoonDefinition;
 @class TyphoonCallStack;
 @class TyphoonRuntimeArguments;
+@class TyphoonTypeConverterRegistry;
 
 /**
 *
@@ -102,6 +103,7 @@ Attach a TyphoonComponentFactoryPostProcessor to this component factory.
     id <TyphoonComponentsPool> _weakSingletons;
 
     TyphoonCallStack *_stack;
+    TyphoonTypeConverterRegistry *_typeConverterRegistry;
     NSMutableArray *_definitionPostProcessors;
     NSMutableArray *_instancePostProcessors;
     BOOL _isLoading;
@@ -171,6 +173,8 @@ Attach a TyphoonComponentFactoryPostProcessor to this component factory.
 
 
 - (NSArray *)registry;
+
+- (TyphoonTypeConverterRegistry *)typeConverterRegistry;
 
 - (void)enumerateDefinitions:(void(^)(TyphoonDefinition *definition, NSUInteger index, TyphoonDefinition **definitionToReplace, BOOL *stop))block;
 

--- a/Source/Factory/TyphoonComponentFactory.m
+++ b/Source/Factory/TyphoonComponentFactory.m
@@ -25,6 +25,7 @@
 #import "TyphoonWeakComponentsPool.h"
 #import "TyphoonFactoryAutoInjectionPostProcessor.h"
 #import "TyphoonStackElement.h"
+#import "TyphoonTypeConverterRegistry.h"
 
 @interface TyphoonDefinition (TyphoonComponentFactory)
 
@@ -75,6 +76,7 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
         _weakSingletons = [TyphoonWeakComponentsPool new];
         _objectGraphSharedInstances = (id<TyphoonComponentsPool>)[[NSMutableDictionary alloc] init];
         _stack = [TyphoonCallStack stack];
+        _typeConverterRegistry = [[TyphoonTypeConverterRegistry alloc] init];
         _definitionPostProcessors = [[NSMutableArray alloc] init];
         _instancePostProcessors = [[NSMutableArray alloc] init];
         [self attachPostProcessor:[TyphoonParentReferenceHydratingPostProcessor new]];
@@ -208,6 +210,10 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
         }
         defaultFactory = self;
     }
+}
+
+- (TyphoonTypeConverterRegistry *)typeConverterRegistry {
+    return _typeConverterRegistry;
 }
 
 - (NSArray *)registry

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -99,7 +99,7 @@
         [_componentFactory addInstancePostProcessor:infrastructureComponent];
     }
     else if ([_definition.type conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
-        [[TyphoonTypeConverterRegistry shared] registerTypeConverter:infrastructureComponent];
+        [_componentFactory.typeConverterRegistry registerTypeConverter:infrastructureComponent];
     }
 }
 

--- a/Source/TypeConversion/Converters/TyphoonNSNumberTypeConverter.m
+++ b/Source/TypeConversion/Converters/TyphoonNSNumberTypeConverter.m
@@ -22,7 +22,7 @@
 
 - (id)convert:(NSString *)stringValue
 {
-    stringValue = [TyphoonTypeConverterRegistry textWithoutTypeFromTextValue:stringValue];
+    stringValue = [TyphoonTypeConversionUtils textWithoutTypeFromTextValue:stringValue];
 
     NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
     [f setNumberStyle:NSNumberFormatterDecimalStyle];

--- a/Source/TypeConversion/Converters/TyphoonNSURLTypeConverter.m
+++ b/Source/TypeConversion/Converters/TyphoonNSURLTypeConverter.m
@@ -22,7 +22,7 @@
 
 - (id)convert:(NSString *)stringValue
 {
-    stringValue = [TyphoonTypeConverterRegistry textWithoutTypeFromTextValue:stringValue];
+    stringValue = [TyphoonTypeConversionUtils textWithoutTypeFromTextValue:stringValue];
     __autoreleasing NSURL *url = [NSURL URLWithString:stringValue];
     return url;
 }

--- a/Source/TypeConversion/Converters/TyphoonPassThroughTypeConverter.m
+++ b/Source/TypeConversion/Converters/TyphoonPassThroughTypeConverter.m
@@ -42,7 +42,7 @@
 
 - (id)convert:(NSString *)stringValue
 {
-    stringValue = [TyphoonTypeConverterRegistry textWithoutTypeFromTextValue:stringValue];
+    stringValue = [TyphoonTypeConversionUtils textWithoutTypeFromTextValue:stringValue];
     
     if (_isMutable) {
         return [NSMutableString stringWithString:stringValue];

--- a/Source/TypeConversion/Converters/TyphoonPrimitiveTypeConverter.h
+++ b/Source/TypeConversion/Converters/TyphoonPrimitiveTypeConverter.h
@@ -13,6 +13,7 @@
 #import <Foundation/Foundation.h>
 #import "TyphoonTypeConverter.h"
 
+@class TyphoonTypeDescriptor;
 
 @interface TyphoonPrimitiveTypeConverter : NSObject
 

--- a/Source/TypeConversion/Helpers/TyphoonColorConversionUtils.h
+++ b/Source/TypeConversion/Helpers/TyphoonColorConversionUtils.h
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+struct RGBA
+{
+    CGFloat red;
+    CGFloat green;
+    CGFloat blue;
+    CGFloat alpha;
+} rgba;
+
+@interface TyphoonColorConversionUtils : NSObject
+
++ (struct RGBA)colorFromHexString:(NSString *)hexString;
++ (struct RGBA)colorFromCssStyleString:(NSString *)cssString;
+
+@end

--- a/Source/TypeConversion/Helpers/TyphoonColorConversionUtils.m
+++ b/Source/TypeConversion/Helpers/TyphoonColorConversionUtils.m
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonColorConversionUtils.h"
+
+@implementation TyphoonColorConversionUtils
+
++ (struct RGBA)colorFromHexString:(NSString *)hexString {
+    hexString =
+    [[hexString stringByReplacingOccurrencesOfString:@"#" withString:@""] stringByReplacingOccurrencesOfString:@"0x" withString:@""];
+    
+    unsigned int red, green, blue, alpha;
+    if ([hexString length] == 6) {
+        sscanf([hexString UTF8String], "%02X%02X%02X", &red, &green, &blue);
+        alpha = 255;
+    }
+    else if ([hexString length] == 8) {
+        sscanf([hexString UTF8String], "%02X%02X%02X%02X", &alpha, &red, &green, &blue);
+    }
+    else {
+        [NSException raise:NSInvalidArgumentException format:@"%@ requires a six or eight digit hex string.",
+         NSStringFromClass([self class])];
+    }
+    return [self colorFromRed:red green:green blue:blue alpha:(CGFloat)(alpha / 255.0)];
+}
+
++ (struct RGBA)colorFromCssStyleString:(NSString *)cssString {
+    NSArray *colorComponents = [cssString componentsSeparatedByString:@","];
+    
+    unsigned int red, green, blue;
+    float alpha;
+    if ([colorComponents count] == 3) {
+        sscanf([cssString UTF8String], "%d,%d,%d", &red, &green, &blue);
+        alpha = 1.0;
+    }
+    else if ([colorComponents count] == 4) {
+        sscanf([cssString UTF8String], "%d,%d,%d,%f", &red, &green, &blue, &alpha);
+    }
+    else {
+        [NSException raise:NSInvalidArgumentException format:@"%@ requires css style format UIColor(r,g,b) or UIColor(r,g,b,a).",
+         NSStringFromClass([self class])];
+    }
+    return [self colorFromRed:red green:green blue:blue alpha:alpha];
+}
+
++ (struct RGBA)colorFromRed:(NSUInteger)red green:(NSUInteger)green blue:(NSUInteger)blue alpha:(CGFloat)alpha
+{
+    struct RGBA color;
+    color.red = (CGFloat)red / 255.0;
+    color.green = (CGFloat)green / 255.0;
+    color.blue = (CGFloat)blue / 255.0;
+    color.alpha = (CGFloat)alpha;
+    return color;
+}
+
+@end

--- a/Source/TypeConversion/TyphoonTypeConversionUtils.h
+++ b/Source/TypeConversion/TyphoonTypeConversionUtils.h
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+/**
+ * A collection of helper methods for type conversion purposes
+ */
+@interface TyphoonTypeConversionUtils : NSObject
+
+/**
+ * Returns the type from the text, e.g. NSURL for NSURL(http://typhoonframework.org)
+ */
++ (NSString *)typeFromTextValue:(NSString *)textValue;
+
+/**
+ * Returns the type from the text, e.g. http://typhoonframework.org for NSURL(http://typhoonframework.org)
+ */
++ (NSString *)textWithoutTypeFromTextValue:(NSString *)textValue;
+
+@end

--- a/Source/TypeConversion/TyphoonTypeConversionUtils.m
+++ b/Source/TypeConversion/TyphoonTypeConversionUtils.m
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonTypeConversionUtils.h"
+
+@implementation TyphoonTypeConversionUtils
+
++ (NSString *)typeFromTextValue:(NSString *)textValue
+{
+    NSString *type = nil;
+    
+    NSRange openBraceRange = [textValue rangeOfString:@"("];
+    BOOL hasBraces = [textValue hasSuffix:@")"] && openBraceRange.location != NSNotFound;
+    if (hasBraces) {
+        type = [textValue substringToIndex:openBraceRange.location];
+    }
+    
+    return type;
+}
+
++ (NSString *)textWithoutTypeFromTextValue:(NSString *)textValue
+{
+    NSString *result = textValue;
+    
+    NSRange openBraceRange = [textValue rangeOfString:@"("];
+    BOOL hasBraces = [textValue hasSuffix:@")"] && openBraceRange.location != NSNotFound;
+    
+    if (hasBraces) {
+        NSRange range = NSMakeRange(openBraceRange.location + openBraceRange.length, 0);
+        range.length = [textValue length] - range.location - 1;
+        result = [textValue substringWithRange:range];
+    }
+    
+    return result;
+}
+
+@end

--- a/Source/TypeConversion/TyphoonTypeConverter.h
+++ b/Source/TypeConversion/TyphoonTypeConverter.h
@@ -12,7 +12,7 @@
 
 #import <Foundation/Foundation.h>
 #import "TyphoonTypeConverterRegistry.h"
-
+#import "TyphoonTypeConversionUtils.h"
 
 /**
 * Declares a contract for converting configuration arguments to their required runtime type.

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.h
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.h
@@ -13,17 +13,12 @@
 #import <Foundation/Foundation.h>
 
 @protocol TyphoonTypeConverter;
-@class TyphoonTypeDescriptor;
 @class TyphoonPrimitiveTypeConverter;
 
 /**
 * Registry of type converters, with special treatment for primitives.
 */
 @interface TyphoonTypeConverterRegistry : NSObject
-{
-    TyphoonPrimitiveTypeConverter *_primitiveTypeConverter;
-    NSMutableDictionary *_typeConverters;
-}
 
 /**
  * Returns the type converter for the given type string. Usually type is class of object you want to convert.

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.h
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.h
@@ -31,10 +31,6 @@
 */
 + (TyphoonTypeConverterRegistry *)shared;
 
-
-+ (NSString *)typeFromTextValue:(NSString *)textValue;
-+ (NSString *)textWithoutTypeFromTextValue:(NSString *)textValue;
-
 /**
  * Returns the type converter for the given type string. Usually type is class of object you want to convert.
  * For example for NSURL type, you should use next syntax in properties file.

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.h
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.h
@@ -16,7 +16,6 @@
 @class TyphoonTypeDescriptor;
 @class TyphoonPrimitiveTypeConverter;
 
-
 /**
 * Registry of type converters, with special treatment for primitives.
 */
@@ -25,11 +24,6 @@
     TyphoonPrimitiveTypeConverter *_primitiveTypeConverter;
     NSMutableDictionary *_typeConverters;
 }
-
-/**
-* Returns the shard/default registry instance used by the container.
-*/
-+ (TyphoonTypeConverterRegistry *)shared;
 
 /**
  * Returns the type converter for the given type string. Usually type is class of object you want to convert.

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.m
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.m
@@ -23,20 +23,6 @@
 @implementation TyphoonTypeConverterRegistry
 
 //-------------------------------------------------------------------------------------------
-#pragma mark - Class Methods
-
-+ (TyphoonTypeConverterRegistry *)shared
-{
-    static dispatch_once_t onceToken;
-    static TyphoonTypeConverterRegistry *instance;
-
-    dispatch_once(&onceToken, ^{
-        instance = [[[self class] alloc] init];
-    });
-    return instance;
-}
-
-//-------------------------------------------------------------------------------------------
 #pragma mark - Initialization & Destruction
 
 - (id)init

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.m
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.m
@@ -19,6 +19,7 @@
 #import "TyphoonNSURLTypeConverter.h"
 #import "TyphoonIntrospectionUtils.h"
 #import "TyphoonNSNumberTypeConverter.h"
+#import "TyphoonNSColorTypeConverter.h"
 
 @interface TyphoonTypeConverterRegistry ()
 
@@ -96,7 +97,7 @@
     }
 #else
     {
-
+        [self registerTypeConverter:[[TyphoonClassFromString(@"TyphoonNSColorTypeConverter") alloc] init]];
     }
 #endif
 }

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.m
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.m
@@ -20,7 +20,6 @@
 #import "TyphoonIntrospectionUtils.h"
 #import "TyphoonNSNumberTypeConverter.h"
 
-
 @implementation TyphoonTypeConverterRegistry
 
 //-------------------------------------------------------------------------------------------
@@ -35,35 +34,6 @@
         instance = [[[self class] alloc] init];
     });
     return instance;
-}
-
-+ (NSString *)typeFromTextValue:(NSString *)textValue
-{
-    NSString *type = nil;
-
-    NSRange openBraceRange = [textValue rangeOfString:@"("];
-    BOOL hasBraces = [textValue hasSuffix:@")"] && openBraceRange.location != NSNotFound;
-    if (hasBraces) {
-        type = [textValue substringToIndex:openBraceRange.location];
-    }
-
-    return type;
-}
-
-+ (NSString *)textWithoutTypeFromTextValue:(NSString *)textValue
-{
-    NSString *result = textValue;
-
-    NSRange openBraceRange = [textValue rangeOfString:@"("];
-    BOOL hasBraces = [textValue hasSuffix:@")"] && openBraceRange.location != NSNotFound;
-
-    if (hasBraces) {
-        NSRange range = NSMakeRange(openBraceRange.location + openBraceRange.length, 0);
-        range.length = [textValue length] - range.location - 1;
-        result = [textValue substringWithRange:range];
-    }
-
-    return result;
 }
 
 //-------------------------------------------------------------------------------------------

--- a/Source/TypeConversion/TyphoonTypeConverterRegistry.m
+++ b/Source/TypeConversion/TyphoonTypeConverterRegistry.m
@@ -20,6 +20,13 @@
 #import "TyphoonIntrospectionUtils.h"
 #import "TyphoonNSNumberTypeConverter.h"
 
+@interface TyphoonTypeConverterRegistry ()
+
+@property (strong, nonatomic) TyphoonPrimitiveTypeConverter *primitiveTypeConverter;
+@property (strong, nonatomic) NSMutableDictionary *typeConverters;
+
+@end
+
 @implementation TyphoonTypeConverterRegistry
 
 //-------------------------------------------------------------------------------------------
@@ -34,8 +41,6 @@
 
         [self registerSharedConverters];
         [self registerPlatformConverters];
-
-
     }
     return self;
 }

--- a/Source/ios/TypeConversion/Converters/TyphoonBundledImageTypeConverter.m
+++ b/Source/ios/TypeConversion/Converters/TyphoonBundledImageTypeConverter.m
@@ -23,7 +23,7 @@
 
 - (id)convert:(NSString *)stringValue
 {
-    stringValue = [TyphoonTypeConverterRegistry textWithoutTypeFromTextValue:stringValue];
+    stringValue = [TyphoonTypeConversionUtils textWithoutTypeFromTextValue:stringValue];
     __autoreleasing UIImage *image = [UIImage imageNamed:stringValue];
     return image;
 }

--- a/Source/ios/TypeConversion/Converters/TyphoonUIColorTypeConverter.m
+++ b/Source/ios/TypeConversion/Converters/TyphoonUIColorTypeConverter.m
@@ -70,7 +70,7 @@
 
 - (id)convert:(NSString *)stringValue
 {
-    stringValue = [TyphoonTypeConverterRegistry textWithoutTypeFromTextValue:stringValue];
+    stringValue = [TyphoonTypeConversionUtils textWithoutTypeFromTextValue:stringValue];
 
     UIColor *color = nil;
 

--- a/Source/osx/TypeConversion/Converters/TyphoonNSColorTypeConverter.h
+++ b/Source/osx/TypeConversion/Converters/TyphoonNSColorTypeConverter.h
@@ -1,0 +1,24 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonTypeConverter.h"
+
+/**
+ * A type converter for NSColor.
+ *
+ * The formats supported are:
+ * Hexadecimal, #RRGGBB or #AARRGGBB
+ * Css-style, rgb(r,g,b) or rgba(r,g,b,a)
+ *
+ */
+@interface TyphoonNSColorTypeConverter : NSObject <TyphoonTypeConverter>
+
+@end

--- a/Source/osx/TypeConversion/Converters/TyphoonNSColorTypeConverter.m
+++ b/Source/osx/TypeConversion/Converters/TyphoonNSColorTypeConverter.m
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2013, Typhoon Framework Contributors
+//  Copyright 2015, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file
@@ -9,19 +9,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-
-#import "TyphoonUIColorTypeConverter.h"
+#import "TyphoonNSColorTypeConverter.h"
 
 #import "TyphoonColorConversionUtils.h"
 
-#import <UIKit/UIKit.h>
-
-
-@implementation TyphoonUIColorTypeConverter
+@implementation TyphoonNSColorTypeConverter
 
 - (id)supportedType
 {
-    return @"UIColor";
+    return @"NSColor";
 }
 
 - (id)convert:(NSString *)stringValue
@@ -40,9 +36,9 @@
     return [self colorFromRGBA:color];
 }
 
-- (UIColor *)colorFromRGBA:(struct RGBA)rgba
+- (NSColor *)colorFromRGBA:(struct RGBA)rgba
 {
-    return [UIColor colorWithRed:rgba.red green:rgba.green blue:rgba.blue alpha:rgba.alpha];
+    return [NSColor colorWithRed:rgba.red green:rgba.green blue:rgba.blue alpha:rgba.alpha];
 }
 
 @end

--- a/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
+++ b/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
@@ -249,6 +249,15 @@
     XCTAssertNotNil(nullConverter);
 }
 
+- (void)test_factories_have_different_converter_registries
+{
+    id existingConverter = [_infrastructureComponentsFactory.typeConverterRegistry converterForType:@"NSNull"];
+    id nonExistingConverter = [_componentFactory.typeConverterRegistry converterForType:@"NSNull"];
+    
+    XCTAssertNotNil(existingConverter);
+    XCTAssertNil(nonExistingConverter);
+}
+
 //-------------------------------------------------------------------------------------------
 #pragma mark - Circular dependencies.
 

--- a/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
+++ b/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
@@ -72,8 +72,8 @@
     // Unregister NSNull converter picked up in infrastructure components assembly.
     // Try/catch to make the correct test fail if converterFor: throws an exception because of missing converter.
     @try {
-        id<TyphoonTypeConverter> converter = [[TyphoonTypeConverterRegistry shared] converterForType:@"NSNull"];
-        [[TyphoonTypeConverterRegistry shared] unregisterTypeConverter:converter];
+        id<TyphoonTypeConverter> converter = [_infrastructureComponentsFactory.typeConverterRegistry converterForType:@"NSNull"];
+        [_infrastructureComponentsFactory.typeConverterRegistry unregisterTypeConverter:converter];
     }
     @catch (NSException *exception) {}
 }
@@ -245,7 +245,7 @@
 
 - (void)test_type_converter_recognized
 {
-    id<TyphoonTypeConverter> nullConverter = [[TyphoonTypeConverterRegistry shared] converterForType:@"NSNull"];
+    id<TyphoonTypeConverter> nullConverter = [_infrastructureComponentsFactory.typeConverterRegistry converterForType:@"NSNull"];
     XCTAssertNotNil(nullConverter);
 }
 

--- a/Tests/OSX/TypeConversion/TyphoonNSColorTypeConverterTests.m
+++ b/Tests/OSX/TypeConversion/TyphoonNSColorTypeConverterTests.m
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2013, Typhoon Framework Contributors
+//  Copyright 2015, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file
@@ -10,37 +10,39 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #import <XCTest/XCTest.h>
+
+#import "TyphoonTypeConverterRegistry.h"
 #import "TyphoonTypeConverter.h"
 
-@interface TyphoonUIColorConverterTests : XCTestCase
+@interface TyphoonNSColorTypeConverterTests : XCTestCase
 
-@property(nonatomic, strong, readonly) UIColor *color;
+@property(nonatomic, strong, readonly) NSColor *color;
 @property(nonatomic, strong) id <TyphoonTypeConverter> converter;
 
 @end
 
-@implementation TyphoonUIColorConverterTests
+@implementation TyphoonNSColorTypeConverterTests
 
-- (void)setUp
-{
+- (void)setUp {
     [super setUp];
+    
     TyphoonTypeConverterRegistry *registry = [[TyphoonTypeConverterRegistry alloc] init];
-    self.converter = [registry converterForType:@"UIColor"];
+    self.converter = [registry converterForType:@"NSColor"];
 }
 
-- (void)tearDown
-{
+- (void)tearDown {
     self.converter = nil;
+    
     [super tearDown];
 }
 
-- (void)assertColor:(UIColor *)color red:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
+- (void)assertColor:(NSColor *)color red:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
 {
     XCTAssertNotNil(color);
-
+    
     CGFloat redComponent, greenComponent, blueComponent, alphaComponent;
     [color getRed:&redComponent green:&greenComponent blue:&blueComponent alpha:&alphaComponent];
-
+    
     XCTAssertEqual(redComponent, red);
     XCTAssertEqual(greenComponent, green);
     XCTAssertEqual(blueComponent, blue);
@@ -49,25 +51,25 @@
 
 - (void)test_converts_hex_string
 {
-    UIColor *color = [self.converter convert:@"UIColor(#ffffff)"];
+    NSColor *color = [self.converter convert:@"NSColor(#ffffff)"];
     [self assertColor:color red:1.0f green:1.0f blue:1.0f alpha:1.0f];
 }
 
 - (void)test_converts_hex_string_with_alpha
 {
-    UIColor *color = [self.converter convert:@"UIColor(#00ffffff)"];
+    NSColor *color = [self.converter convert:@"NSColor(#00ffffff)"];
     [self assertColor:color red:1.0f green:1.0f blue:1.0f alpha:0.0f];
 }
 
 - (void)test_converts_css_style_rgb
 {
-    UIColor *color = [self.converter convert:@"UIColor(255,255,255)"];
+    NSColor *color = [self.converter convert:@"NSColor(255,255,255)"];
     [self assertColor:color red:1.0f green:1.0f blue:1.0f alpha:1.0f];
 }
 
 - (void)test_converts_css_style_rgba
 {
-    UIColor *color = [self.converter convert:@"UIColor(255,255,255,0.5)"];
+    NSColor *color = [self.converter convert:@"NSColor(255,255,255,0.5)"];
     [self assertColor:color red:1.0f green:1.0f blue:1.0f alpha:0.5f];
 }
 

--- a/Tests/TypeConversion/TyphoonNSNumberTypeConverterTests.m
+++ b/Tests/TypeConversion/TyphoonNSNumberTypeConverterTests.m
@@ -25,7 +25,14 @@
 - (void)setUp
 {
     [super setUp];
-    self.converter = [[TyphoonTypeConverterRegistry shared] converterForType:@"NSNumber"];
+    TyphoonTypeConverterRegistry *registry = [[TyphoonTypeConverterRegistry alloc] init];
+    self.converter = [registry converterForType:@"NSNumber"];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    self.converter = nil;
 }
 
 - (void)test_converts_integer

--- a/Tests/TypeConversion/TyphoonPassthroughTypeConverterTests.m
+++ b/Tests/TypeConversion/TyphoonPassthroughTypeConverterTests.m
@@ -15,17 +15,29 @@
 
 @interface TyphoonPassThroughTypeConverterTests : XCTestCase
 
+@property TyphoonTypeConverterRegistry *registry;
 @property NSString *aStringProperty;
 @property NSMutableString *aMutableStringProperty;
-
 
 @end
 
 @implementation TyphoonPassThroughTypeConverterTests
 
+- (void)setUp
+{
+    [super setUp];
+    self.registry = [[TyphoonTypeConverterRegistry alloc] init];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    self.registry = nil;
+}
+
 - (void)test_forwards_NSString
 {
-    id <TyphoonTypeConverter> converter = [[TyphoonTypeConverterRegistry shared] converterForType:@"NSString"];
+    id <TyphoonTypeConverter> converter = [self.registry converterForType:@"NSString"];
     NSString *converted = [converter convert:@"foobar foobar"];
     XCTAssertEqual(converted, @"foobar foobar");
     XCTAssertTrue([converted isKindOfClass:[NSString class]]);
@@ -33,7 +45,7 @@
 
 - (void)test_forwards_NSMutableString
 {
-    id <TyphoonTypeConverter> converter = [[TyphoonTypeConverterRegistry shared] converterForType:@"NSMutableString"];
+    id <TyphoonTypeConverter> converter = [self.registry converterForType:@"NSMutableString"];
     NSString *converted = [converter convert:@"foobar foobar"];
     XCTAssertEqualObjects(converted, @"foobar foobar");
     XCTAssertTrue([converted isKindOfClass:[NSMutableString class]]);

--- a/Tests/TypeConversion/TyphoonTypeConversionUtilsTests.m
+++ b/Tests/TypeConversion/TyphoonTypeConversionUtilsTests.m
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <XCTest/XCTest.h>
+
+#import "TyphoonTypeConversionUtils.h"
+
+@interface TyphoonTypeConversionUtilsTests : XCTestCase
+
+@end
+
+@implementation TyphoonTypeConversionUtilsTests
+
+- (void)test_obtaining_type_from_text
+{
+    NSString *testString = @"NSURL(http://typhoonframework.org)";
+    NSString *expectedResult = @"NSURL";
+    
+    NSString *result = [TyphoonTypeConversionUtils typeFromTextValue:testString];
+    
+    XCTAssertEqualObjects(result, expectedResult);
+}
+
+- (void)test_obtaining_text_without_type
+{
+    NSString *testString = @"NSURL(http://typhoonframework.org)";
+    NSString *expectedResult = @"http://typhoonframework.org";
+    
+    NSString *result = [TyphoonTypeConversionUtils textWithoutTypeFromTextValue:testString];
+    
+    XCTAssertEqualObjects(result, expectedResult);
+}
+
+@end

--- a/Tests/TypeConversion/TyphoonTypeConverterRegistryTests.m
+++ b/Tests/TypeConversion/TyphoonTypeConverterRegistryTests.m
@@ -54,7 +54,15 @@
     @catch (NSException *e) {
         XCTAssertEqualObjects([e description], @"Converter for 'NSURL' already registered.");
     }
+}
 
+- (void)test_unregisters_converter
+{
+    id <TyphoonTypeConverter> converter = [self.registry converterForType:@"NSURL"];
+    [self.registry unregisterTypeConverter:converter];
+    
+    converter = [self.registry converterForType:@"NSURL"];
+    XCTAssertNil(converter);
 }
 
 @end

--- a/Tests/TypeConversion/TyphoonTypeConverterRegistryTests.m
+++ b/Tests/TypeConversion/TyphoonTypeConverterRegistryTests.m
@@ -20,22 +20,27 @@
 @interface TyphoonTypeConverterRegistryTests : XCTestCase
 
 @property(nonatomic, strong) NSData *data;
+@property TyphoonTypeConverterRegistry *registry;
 
 @end
 
 @implementation TyphoonTypeConverterRegistryTests
-{
-    TyphoonTypeConverterRegistry *_registry;
-}
 
 - (void)setUp
 {
-    _registry = [TyphoonTypeConverterRegistry shared];
+    [super setUp];
+    self.registry = [[TyphoonTypeConverterRegistry alloc] init];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    self.registry = nil;
 }
 
 - (void)test_raises_exception_when_converter_class_not_registered
 {
-    id <TyphoonTypeConverter> converter = [[TyphoonTypeConverterRegistry shared] converterForType:@"NSData"];
+    id <TyphoonTypeConverter> converter = [self.registry converterForType:@"NSData"];
     XCTAssertNil(converter);
 }
 

--- a/Tests/iOS/TypeConversion/TyphoonUIColorConverterTests.m
+++ b/Tests/iOS/TypeConversion/TyphoonUIColorConverterTests.m
@@ -24,8 +24,15 @@
 - (void)setUp
 {
     [super setUp];
-    self.converter = [[TyphoonTypeConverterRegistry shared] converterForType:@"UIColor"];
+    TyphoonTypeConverterRegistry *registry = [[TyphoonTypeConverterRegistry alloc] init];
+    self.converter = [registry converterForType:@"UIColor"];
 
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    self.converter = nil;
 }
 
 - (void)assertColor:(UIColor *)color red:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -352,8 +352,8 @@
 		8946F2E01B8E403E005C4954 /* TyphoonViewHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 8946F2DF1B8E403E005C4954 /* TyphoonViewHelpers.m */; };
 		8994D47E1B55BA6600662766 /* ClassForNoSubclass.m in Sources */ = {isa = PBXBuildFile; fileRef = 8994D47D1B55BA6600662766 /* ClassForNoSubclass.m */; };
 		8994D47F1B55BA6600662766 /* ClassForNoSubclass.m in Sources */ = {isa = PBXBuildFile; fileRef = 8994D47D1B55BA6600662766 /* ClassForNoSubclass.m */; };
-		89FAD3211BA7C65900D3546B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; settings = {ASSET_TAGS = (); }; };
-		89FAD3221BA7C66300D3546B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; settings = {ASSET_TAGS = (); }; };
+		89FAD3211BA7C65900D3546B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; };
+		89FAD3221BA7C66300D3546B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; };
 		905214711A3770AE006A935B /* OCLogTemplate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F911936F63A0083714E /* OCLogTemplate.h */; };
 		90ABC3F51A36B09E008D8162 /* Typhoon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90ABC3EA1A36B09E008D8162 /* Typhoon.framework */; };
 		90ABC4031A36B0BA008D8162 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B076E611936F5850083714E /* UIKit.framework */; };
@@ -525,9 +525,12 @@
 		90ABC4D61A36BA53008D8162 /* TyphoonFrameworkSwiftExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90ABC4D51A36BA53008D8162 /* TyphoonFrameworkSwiftExampleTests.swift */; };
 		90ABC4E21A36BAE5008D8162 /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90ABC4E11A36BAE5008D8162 /* Assembly.swift */; };
 		9F0591DF1BE883E4007CCB9C /* TyphoonLoadedView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA1F7A42D15F175F25EF57 /* TyphoonLoadedView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F0591E01BE88404007CCB9C /* TyphoonViewHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 8946F2DE1B8E403E005C4954 /* TyphoonViewHelpers.h */; settings = {ASSET_TAGS = (); }; };
-		9F0591E11BE88408007CCB9C /* TyphoonStoryboardProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */; settings = {ASSET_TAGS = (); }; };
-		9F0591E21BE8847D007CCB9C /* TyphoonInjectionDefinition.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA1463AEC1B97752A6DF8C /* TyphoonInjectionDefinition.h */; settings = {ASSET_TAGS = (); }; };
+		9F0591E01BE88404007CCB9C /* TyphoonViewHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 8946F2DE1B8E403E005C4954 /* TyphoonViewHelpers.h */; };
+		9F0591E11BE88408007CCB9C /* TyphoonStoryboardProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */; };
+		9F0591E21BE8847D007CCB9C /* TyphoonInjectionDefinition.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA1463AEC1B97752A6DF8C /* TyphoonInjectionDefinition.h */; };
+		9F0F25141BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */; };
+		9F0F25151BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */; };
+		9F0F25171BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25161BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -1086,6 +1089,9 @@
 		90ABC4D41A36BA53008D8162 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		90ABC4D51A36BA53008D8162 /* TyphoonFrameworkSwiftExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TyphoonFrameworkSwiftExampleTests.swift; sourceTree = "<group>"; };
 		90ABC4E11A36BAE5008D8162 /* Assembly.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assembly.swift; sourceTree = "<group>"; };
+		9F0F25121BEA1267002AD880 /* TyphoonTypeConversionUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonTypeConversionUtils.h; sourceTree = "<group>"; };
+		9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonTypeConversionUtils.m; sourceTree = "<group>"; };
+		9F0F25161BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonTypeConversionUtilsTests.m; sourceTree = "<group>"; };
 		9F2C08A61BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonCollaboratingAssembliesCollector.h; sourceTree = "<group>"; };
 		9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollector.m; sourceTree = "<group>"; };
 		9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollectorTests.m; sourceTree = "<group>"; };
@@ -1721,6 +1727,8 @@
 				6B076F701936F63A0083714E /* TyphoonTypeConverterRegistry.m */,
 				6B076F711936F63A0083714E /* TyphoonTypeDescriptor.h */,
 				6B076F721936F63A0083714E /* TyphoonTypeDescriptor.m */,
+				9F0F25121BEA1267002AD880 /* TyphoonTypeConversionUtils.h */,
+				9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */,
 			);
 			path = TypeConversion;
 			sourceTree = "<group>";
@@ -2182,6 +2190,7 @@
 				6B0770851936F63A0083714E /* TyphoonTypeConverterRegistryTests.m */,
 				6B0770861936F63A0083714E /* TyphoonTypeDescriptorTests.m */,
 				BA798E8847C809A44EA1116F /* TyphoonNSNumberTypeConverterTests.m */,
+				9F0F25161BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m */,
 			);
 			path = TypeConversion;
 			sourceTree = "<group>";
@@ -2876,6 +2885,7 @@
 				6B0770C81936F9000083714E /* TyphoonFactoryPropertyInjectionPostProcessor.m in Sources */,
 				6B0770C91936F9000083714E /* TyphoonParentReferenceHydratingPostProcessor.m in Sources */,
 				9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */,
+				9F0F25141BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */,
 				6B0770CA1936F9000083714E /* TyphoonStackElement.m in Sources */,
 				6B0770CB1936F9000083714E /* TyphoonWeakComponentsPool.m in Sources */,
 				6B0770DD1936F9000083714E /* TyphoonComponentFactory.m in Sources */,
@@ -2954,6 +2964,7 @@
 				6B07711A1936FEA80083714E /* SimpleAssembly.m in Sources */,
 				6B07711B1936FEA80083714E /* SingletonsChainAssembly.m in Sources */,
 				6B0771201936FEA80083714E /* ClassWithConstructor.m in Sources */,
+				9F0F25171BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m in Sources */,
 				6B0771211936FEA80083714E /* PrimitiveMan.m in Sources */,
 				6B0771221936FEA80083714E /* TyphoonComponentDefinition+InstanceBuilderTests.m in Sources */,
 				6B0771341936FEA80083714E /* TyphoonComponentFactoryTests.m in Sources */,
@@ -3075,6 +3086,7 @@
 				9F65CEE21BA1555A0015765B /* TyphoonAssemblyBuilder.m in Sources */,
 				6B0773B21937831B0083714E /* TyphoonMethod.m in Sources */,
 				6B0773B31937831B0083714E /* TyphoonDefinition.m in Sources */,
+				9F0F25151BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */,
 				6B0773B51937831B0083714E /* TyphoonAssembly.m in Sources */,
 				6B0773BF1937831B0083714E /* NSInvocation+TCFInstanceBuilder.m in Sources */,
 				6B0773C01937831B0083714E /* NSInvocation+TCFUnwrapValues.m in Sources */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -417,7 +417,6 @@
 		90ABC4461A36B1B4008D8162 /* TyphoonPassThroughTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F6B1936F63A0083714E /* TyphoonPassThroughTypeConverter.m */; };
 		90ABC4471A36B1B4008D8162 /* TyphoonPrimitiveTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F6D1936F63A0083714E /* TyphoonPrimitiveTypeConverter.m */; };
 		90ABC4481A36B1B4008D8162 /* TyphoonNSNumberTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = BA79809B312F99BCEDF489BD /* TyphoonNSNumberTypeConverter.m */; };
-		90ABC4491A36B1B4008D8162 /* NSNullTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7984A11531DFDE00C583DE /* NSNullTypeConverter.m */; };
 		90ABC44A1A36B1B4008D8162 /* TyphoonTypeConverterRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F701936F63A0083714E /* TyphoonTypeConverterRegistry.m */; };
 		90ABC44B1A36B1B4008D8162 /* TyphoonTypeDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F721936F63A0083714E /* TyphoonTypeDescriptor.m */; };
 		90ABC44C1A36B1B4008D8162 /* NSArray+TyphoonManualEnumeration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F781936F63A0083714E /* NSArray+TyphoonManualEnumeration.m */; };
@@ -502,7 +501,6 @@
 		90ABC4A41A36B2A2008D8162 /* TyphoonPassThroughTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F6A1936F63A0083714E /* TyphoonPassThroughTypeConverter.h */; };
 		90ABC4A51A36B2A2008D8162 /* TyphoonPrimitiveTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F6C1936F63A0083714E /* TyphoonPrimitiveTypeConverter.h */; };
 		90ABC4A61A36B2A2008D8162 /* TyphoonNSNumberTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = BA79856305370AE9A94F8B87 /* TyphoonNSNumberTypeConverter.h */; };
-		90ABC4A71A36B2A2008D8162 /* NSNullTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = BA798BFD251D2908121708F3 /* NSNullTypeConverter.h */; };
 		90ABC4A81A36B2A2008D8162 /* TyphoonTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F6E1936F63A0083714E /* TyphoonTypeConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90ABC4A91A36B2A2008D8162 /* TyphoonTypeConverterRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F6F1936F63A0083714E /* TyphoonTypeConverterRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90ABC4AA1A36B2A2008D8162 /* TyphoonTypeDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F711936F63A0083714E /* TyphoonTypeDescriptor.h */; };
@@ -531,6 +529,7 @@
 		9F0F25141BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */; };
 		9F0F25151BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */; };
 		9F0F25171BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25161BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m */; };
+		9F0F25211BEA22B0002AD880 /* TyphoonTypeConversionUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0F25121BEA1267002AD880 /* TyphoonTypeConversionUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -1125,7 +1124,7 @@
 		BA7983C7D0A3DFE423250300 /* StoryboardControllerDependency.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoryboardControllerDependency.m; sourceTree = "<group>"; };
 		BA79842846CF608977332EB1 /* TyphoonAssemblyActivator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonAssemblyActivator.m; sourceTree = "<group>"; };
 		BA798469B0CE41697FE61E89 /* TyphoonBlockComponentFactory_OverridingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonBlockComponentFactory_OverridingTests.m; sourceTree = "<group>"; };
-		BA7984A11531DFDE00C583DE /* NSNullTypeConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSNullTypeConverter.m; sourceTree = "<group>"; };
+		BA7984A11531DFDE00C583DE /* NSNullTypeConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSNullTypeConverter.m; path = ../../Source/TypeConversion/Converters/NSNullTypeConverter.m; sourceTree = "<group>"; };
 		BA7984B1561B33C77457A36F /* TyphoonStartupTests_iOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonStartupTests_iOS.m; sourceTree = "<group>"; };
 		BA7984DDD3DD517C6C94BA69 /* ConfigAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigAssembly.h; sourceTree = "<group>"; };
 		BA7984E001941FD55401039C /* TyphoonAssemblyAdviser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonAssemblyAdviser.h; sourceTree = "<group>"; };
@@ -1159,7 +1158,7 @@
 		BA798B7BB085030D07102B8E /* Storyboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = "<group>"; };
 		BA798BEE5436A26C0BC26B12 /* TyphoonAssemblySelectorAdviserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonAssemblySelectorAdviserTests.m; sourceTree = "<group>"; };
 		BA798BF1F83FE18A35E5CEB8 /* TyphoonBlockComponentFactory_CollectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonBlockComponentFactory_CollectionTests.m; sourceTree = "<group>"; };
-		BA798BFD251D2908121708F3 /* NSNullTypeConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSNullTypeConverter.h; sourceTree = "<group>"; };
+		BA798BFD251D2908121708F3 /* NSNullTypeConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSNullTypeConverter.h; path = ../../Source/TypeConversion/Converters/NSNullTypeConverter.h; sourceTree = "<group>"; };
 		BA798C36DD67C0C40FFC8515 /* TyphoonBlockComponentFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonBlockComponentFactory.h; sourceTree = "<group>"; };
 		BA798C5226FD3738A33BE396 /* InvalidCollaboratingAssembly_Initializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InvalidCollaboratingAssembly_Initializer.h; sourceTree = "<group>"; };
 		BA798CAB2EE92B9A572C7DDF /* TyphoonAssemblyAdviser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonAssemblyAdviser.m; sourceTree = "<group>"; };
@@ -1744,8 +1743,6 @@
 				6B076F6D1936F63A0083714E /* TyphoonPrimitiveTypeConverter.m */,
 				BA79809B312F99BCEDF489BD /* TyphoonNSNumberTypeConverter.m */,
 				BA79856305370AE9A94F8B87 /* TyphoonNSNumberTypeConverter.h */,
-				BA798BFD251D2908121708F3 /* NSNullTypeConverter.h */,
-				BA7984A11531DFDE00C583DE /* NSNullTypeConverter.m */,
 			);
 			path = Converters;
 			sourceTree = "<group>";
@@ -2183,6 +2180,8 @@
 		6B07707E1936F63A0083714E /* TypeConversion */ = {
 			isa = PBXGroup;
 			children = (
+				BA798BFD251D2908121708F3 /* NSNullTypeConverter.h */,
+				BA7984A11531DFDE00C583DE /* NSNullTypeConverter.m */,
 				6B07707F1936F63A0083714E /* ClassWithPrimitiveTypesForConversion.h */,
 				6B0770801936F63A0083714E /* ClassWithPrimitiveTypesForConversion.m */,
 				6B0770831936F63A0083714E /* TyphoonPassthroughTypeConverterTests.m */,
@@ -2497,7 +2496,6 @@
 				90ABC4A41A36B2A2008D8162 /* TyphoonPassThroughTypeConverter.h in Headers */,
 				90ABC4A51A36B2A2008D8162 /* TyphoonPrimitiveTypeConverter.h in Headers */,
 				90ABC4A61A36B2A2008D8162 /* TyphoonNSNumberTypeConverter.h in Headers */,
-				90ABC4A71A36B2A2008D8162 /* NSNullTypeConverter.h in Headers */,
 				90ABC4AA1A36B2A2008D8162 /* TyphoonTypeDescriptor.h in Headers */,
 				90ABC4AC1A36B2A3008D8162 /* NSArray+TyphoonManualEnumeration.h in Headers */,
 				90ABC4AD1A36B2A3008D8162 /* NSObject+DeallocNotification.h in Headers */,
@@ -2517,6 +2515,7 @@
 				BA798A97C60EC12681B6AAF4 /* TyphoonAssemblyDefinitionBuilder.h in Headers */,
 				A56819061AA9403000ECC4F9 /* TyphoonAssemblyActivator.h in Headers */,
 				BA7989F2E1964F1A160DA5C9 /* TyphoonAssemblyAdviser.h in Headers */,
+				9F0F25211BEA22B0002AD880 /* TyphoonTypeConversionUtils.h in Headers */,
 				BA798DE716F71FA56F29F8BB /* TyphoonAssemblyPropertyInjectionPostProcessor.h in Headers */,
 				BA798EBDD083DCB98251DEAD /* TyphoonRuntimeArguments.h in Headers */,
 				BA798B131A19FFFD8F8941C0 /* TyphoonAssemblySelectorAdviser.h in Headers */,
@@ -3323,7 +3322,6 @@
 				90ABC4461A36B1B4008D8162 /* TyphoonPassThroughTypeConverter.m in Sources */,
 				90ABC4471A36B1B4008D8162 /* TyphoonPrimitiveTypeConverter.m in Sources */,
 				90ABC4481A36B1B4008D8162 /* TyphoonNSNumberTypeConverter.m in Sources */,
-				90ABC4491A36B1B4008D8162 /* NSNullTypeConverter.m in Sources */,
 				90ABC44A1A36B1B4008D8162 /* TyphoonTypeConverterRegistry.m in Sources */,
 				90ABC44B1A36B1B4008D8162 /* TyphoonTypeDescriptor.m in Sources */,
 				90ABC44C1A36B1B4008D8162 /* NSArray+TyphoonManualEnumeration.m in Sources */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 		90ABC49B1A36B2A1008D8162 /* TyphoonViewControllerNibResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F4F1936F63A0083714E /* TyphoonViewControllerNibResolver.h */; };
 		90ABC49C1A36B2A1008D8162 /* TyphoonStoryboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F521936F63A0083714E /* TyphoonStoryboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90ABC49D1A36B2A1008D8162 /* TyphoonStoryboardResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA129FBD11BA18D318694D /* TyphoonStoryboardResolver.h */; };
-		90ABC49E1A36B2A1008D8162 /* TyphoonBundledImageTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F561936F63A0083714E /* TyphoonBundledImageTypeConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90ABC49E1A36B2A1008D8162 /* TyphoonBundledImageTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F561936F63A0083714E /* TyphoonBundledImageTypeConverter.h */; };
 		90ABC49F1A36B2A1008D8162 /* TyphoonUIColorTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F581936F63A0083714E /* TyphoonUIColorTypeConverter.h */; };
 		90ABC4A01A36B2A2008D8162 /* TyphooniOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F5A1936F63A0083714E /* TyphooniOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90ABC4A11A36B2A2008D8162 /* TyphoonPatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B076F5F1936F63A0083714E /* TyphoonPatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -536,6 +536,8 @@
 		9F0F25301BEA2571002AD880 /* TyphoonColorConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */; };
 		9F0F25311BEA27A7002AD880 /* TyphoonColorConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */; };
 		9F0F25321BEA27A9002AD880 /* TyphoonColorConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */; };
+		9F0F25331BEA2845002AD880 /* TyphoonNSColorTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0F25241BEA2327002AD880 /* TyphoonNSColorTypeConverter.h */; };
+		9F0F25341BEA2859002AD880 /* TyphoonColorConversionUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0F252E1BEA2571002AD880 /* TyphoonColorConversionUtils.h */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -2489,6 +2491,7 @@
 				90ABC4761A36B29F008D8162 /* TyphoonDefinition+Infrastructure.h in Headers */,
 				90ABC47C1A36B29F008D8162 /* TyphoonMethod.h in Headers */,
 				905214711A3770AE006A935B /* OCLogTemplate.h in Headers */,
+				9F0F25341BEA2859002AD880 /* TyphoonColorConversionUtils.h in Headers */,
 				90ABC4531A36B29E008D8162 /* TyphoonOptionMatcher+Internal.h in Headers */,
 				90ABC4571A36B29E008D8162 /* TyphoonConfiguration.h in Headers */,
 				90ABC4581A36B29E008D8162 /* TyphoonJsonStyleConfiguration.h in Headers */,
@@ -2522,6 +2525,7 @@
 				90ABC4791A36B29F008D8162 /* TyphoonReferenceDefinition.h in Headers */,
 				90ABC47B1A36B29F008D8162 /* TyphoonMethod+InstanceBuilder.h in Headers */,
 				90ABC4801A36B29F008D8162 /* TyphoonFactoryAutoInjectionPostProcessor.h in Headers */,
+				9F0F25331BEA2845002AD880 /* TyphoonNSColorTypeConverter.h in Headers */,
 				90ABC4811A36B29F008D8162 /* TyphoonAssembly+TyphoonAssemblyFriend.h in Headers */,
 				90ABC48D1A36B2A0008D8162 /* NSInvocation+TCFInstanceBuilder.h in Headers */,
 				90ABC48E1A36B2A0008D8162 /* NSInvocation+TCFUnwrapValues.h in Headers */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -530,6 +530,12 @@
 		9F0F25151BEA1267002AD880 /* TyphoonTypeConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */; };
 		9F0F25171BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25161BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m */; };
 		9F0F25211BEA22B0002AD880 /* TyphoonTypeConversionUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0F25121BEA1267002AD880 /* TyphoonTypeConversionUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F0F25271BEA2374002AD880 /* TyphoonNSColorTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25251BEA2327002AD880 /* TyphoonNSColorTypeConverter.m */; };
+		9F0F25281BEA237B002AD880 /* TyphoonNSColorTypeConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25251BEA2327002AD880 /* TyphoonNSColorTypeConverter.m */; };
+		9F0F252C1BEA240B002AD880 /* TyphoonNSColorTypeConverterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252A1BEA23E6002AD880 /* TyphoonNSColorTypeConverterTests.m */; };
+		9F0F25301BEA2571002AD880 /* TyphoonColorConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */; };
+		9F0F25311BEA27A7002AD880 /* TyphoonColorConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */; };
+		9F0F25321BEA27A9002AD880 /* TyphoonColorConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -1091,6 +1097,11 @@
 		9F0F25121BEA1267002AD880 /* TyphoonTypeConversionUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonTypeConversionUtils.h; sourceTree = "<group>"; };
 		9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonTypeConversionUtils.m; sourceTree = "<group>"; };
 		9F0F25161BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonTypeConversionUtilsTests.m; sourceTree = "<group>"; };
+		9F0F25241BEA2327002AD880 /* TyphoonNSColorTypeConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonNSColorTypeConverter.h; path = TypeConversion/Converters/TyphoonNSColorTypeConverter.h; sourceTree = "<group>"; };
+		9F0F25251BEA2327002AD880 /* TyphoonNSColorTypeConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonNSColorTypeConverter.m; path = TypeConversion/Converters/TyphoonNSColorTypeConverter.m; sourceTree = "<group>"; };
+		9F0F252A1BEA23E6002AD880 /* TyphoonNSColorTypeConverterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonNSColorTypeConverterTests.m; path = Tests/OSX/TypeConversion/TyphoonNSColorTypeConverterTests.m; sourceTree = SOURCE_ROOT; };
+		9F0F252E1BEA2571002AD880 /* TyphoonColorConversionUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonColorConversionUtils.h; path = Helpers/TyphoonColorConversionUtils.h; sourceTree = "<group>"; };
+		9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonColorConversionUtils.m; path = Helpers/TyphoonColorConversionUtils.m; sourceTree = "<group>"; };
 		9F2C08A61BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonCollaboratingAssembliesCollector.h; sourceTree = "<group>"; };
 		9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollector.m; sourceTree = "<group>"; };
 		9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollectorTests.m; sourceTree = "<group>"; };
@@ -1685,6 +1696,7 @@
 		6B076F5B1936F63A0083714E /* osx */ = {
 			isa = PBXGroup;
 			children = (
+				9F0F25221BEA22FB002AD880 /* TypeConversion */,
 				6B076F5C1936F63A0083714E /* .gitkeep */,
 			);
 			path = osx;
@@ -1720,6 +1732,7 @@
 		6B076F661936F63A0083714E /* TypeConversion */ = {
 			isa = PBXGroup;
 			children = (
+				9F0F252D1BEA2546002AD880 /* Helpers */,
 				6B076F671936F63A0083714E /* Converters */,
 				6B076F6E1936F63A0083714E /* TyphoonTypeConverter.h */,
 				6B076F6F1936F63A0083714E /* TyphoonTypeConverterRegistry.h */,
@@ -2226,6 +2239,7 @@
 				6B077375193780580083714E /* OCMockito.framework */,
 				6B077376193780580083714E /* Typhoon-osx */,
 				6B077383193780580083714E /* Typhoon-osxTests */,
+				9F0F25291BEA23C6002AD880 /* TypeConversion */,
 			);
 			path = osx;
 			sourceTree = "<group>";
@@ -2331,6 +2345,40 @@
 			children = (
 			);
 			name = Startup;
+			sourceTree = "<group>";
+		};
+		9F0F25221BEA22FB002AD880 /* TypeConversion */ = {
+			isa = PBXGroup;
+			children = (
+				9F0F25231BEA2302002AD880 /* Converters */,
+			);
+			name = TypeConversion;
+			sourceTree = "<group>";
+		};
+		9F0F25231BEA2302002AD880 /* Converters */ = {
+			isa = PBXGroup;
+			children = (
+				9F0F25241BEA2327002AD880 /* TyphoonNSColorTypeConverter.h */,
+				9F0F25251BEA2327002AD880 /* TyphoonNSColorTypeConverter.m */,
+			);
+			name = Converters;
+			sourceTree = "<group>";
+		};
+		9F0F25291BEA23C6002AD880 /* TypeConversion */ = {
+			isa = PBXGroup;
+			children = (
+				9F0F252A1BEA23E6002AD880 /* TyphoonNSColorTypeConverterTests.m */,
+			);
+			name = TypeConversion;
+			sourceTree = "<group>";
+		};
+		9F0F252D1BEA2546002AD880 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				9F0F252E1BEA2571002AD880 /* TyphoonColorConversionUtils.h */,
+				9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */,
+			);
+			name = Helpers;
 			sourceTree = "<group>";
 		};
 		9FDF58CF1BA4165700678B2B /* StoryboardProvider */ = {
@@ -2922,6 +2970,7 @@
 				BA7984CB072392CFA8BD875F /* iOSPlistConfiguredAssembly.m in Sources */,
 				BA79806A52A10605DC97BDF9 /* CavalryMan.m in Sources */,
 				BA798D3A9A5F003A4DA84698 /* Knight.m in Sources */,
+				9F0F25301BEA2571002AD880 /* TyphoonColorConversionUtils.m in Sources */,
 				2DBA133CA352D9C555482734 /* TyphoonInjectionDefinition.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3103,6 +3152,7 @@
 				6B0773DC1937831B0083714E /* TyphoonPatcher.m in Sources */,
 				6B0773DE1937831B0083714E /* TyphoonTestUtils.m in Sources */,
 				6B0773DF1937831B0083714E /* TyphoonNSURLTypeConverter.m in Sources */,
+				9F0F25271BEA2374002AD880 /* TyphoonNSColorTypeConverter.m in Sources */,
 				6B0773E01937831B0083714E /* TyphoonPassThroughTypeConverter.m in Sources */,
 				9F65CEE51BA1555D0015765B /* TyphoonAssemblyBuilder+PlistProcessor.m in Sources */,
 				6B0773E11937831B0083714E /* TyphoonPrimitiveTypeConverter.m in Sources */,
@@ -3113,6 +3163,7 @@
 				6B0773E61937831B0083714E /* NSObject+PropertyInjection.m in Sources */,
 				6B0773E71937831B0083714E /* NSObject+TyphoonIntrospectionUtils.m in Sources */,
 				6B0773E81937831B0083714E /* TyphoonSwizzlerDefaultImpl.m in Sources */,
+				9F0F25311BEA27A7002AD880 /* TyphoonColorConversionUtils.m in Sources */,
 				6B0773E91937831B0083714E /* TyphoonIntrospectionUtils.m in Sources */,
 				6B0773EB1937831B0083714E /* TyphoonSelector.m in Sources */,
 				6B07738E193780790083714E /* TyphoonOSXAppDelegate.m in Sources */,
@@ -3159,6 +3210,7 @@
 				9F98B2EB1BA0BF5E00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */,
 				6B0773F91937839D0083714E /* ComponentFactoryAwareObject.m in Sources */,
 				6B0773FA1937839D0083714E /* TyphoonComponentFactoryAwareTests.m in Sources */,
+				9F0F252C1BEA240B002AD880 /* TyphoonNSColorTypeConverterTests.m in Sources */,
 				6B0773FB1937839D0083714E /* ClassWithCollectionProperties.m in Sources */,
 				6B0773FC1937839D0083714E /* TyphoonPropertyInjectedAsCollectionTests.m in Sources */,
 				6B0773FD1937839D0083714E /* FactoryReferenceInjectionsTests.m in Sources */,
@@ -3298,6 +3350,7 @@
 				90ABC4271A36B1B4008D8162 /* TyphoonFactoryAutoInjectionPostProcessor.m in Sources */,
 				9F65CEE61BA1555E0015765B /* TyphoonAssemblyBuilder+PlistProcessor.m in Sources */,
 				90ABC4281A36B1B4008D8162 /* TyphoonAssembly.m in Sources */,
+				9F0F25321BEA27A9002AD880 /* TyphoonColorConversionUtils.m in Sources */,
 				90ABC4321A36B1B4008D8162 /* NSInvocation+TCFInstanceBuilder.m in Sources */,
 				90ABC4331A36B1B4008D8162 /* NSInvocation+TCFUnwrapValues.m in Sources */,
 				90ABC4341A36B1B4008D8162 /* NSMethodSignature+TCFUnwrapValues.m in Sources */,
@@ -3318,6 +3371,7 @@
 				90ABC4421A36B1B4008D8162 /* TyphoonUIColorTypeConverter.m in Sources */,
 				90ABC4431A36B1B4008D8162 /* TyphoonPatcher.m in Sources */,
 				90ABC4441A36B1B4008D8162 /* TyphoonTestUtils.m in Sources */,
+				9F0F25281BEA237B002AD880 /* TyphoonNSColorTypeConverter.m in Sources */,
 				90ABC4451A36B1B4008D8162 /* TyphoonNSURLTypeConverter.m in Sources */,
 				90ABC4461A36B1B4008D8162 /* TyphoonPassThroughTypeConverter.m in Sources */,
 				90ABC4471A36B1B4008D8162 /* TyphoonPrimitiveTypeConverter.m in Sources */,


### PR DESCRIPTION
This PR fixes the Issue #407. `TyphoonTypeConverterRegistry` is now not a shared variable, but relates to `TyphoonComponentFactory`.

Besides it, I've added a couple of new unit tests and a `TyphoonNSColorTypeConverter`, as an OSX opposite of `TyphoonUIColorTypeConverter`.