### PR TITLE
Preattaching infrastructure components

### DIFF
--- a/Source/Configuration/Startup/TyphoonStartup.m
+++ b/Source/Configuration/Startup/TyphoonStartup.m
@@ -129,7 +129,7 @@ static BOOL initialFactoryWasCreated = NO;
         if (initialFactory) {
             id<TyphoonDefinitionPostProcessor> processor = [self configPostProcessor];
             if (processor) {
-                [initialFactory attachPostProcessor:processor];
+                [initialFactory attachDefinitionPostProcessor:processor];
             }
             [self injectInitialFactoryIntoDelegate:delegate];
             [TyphoonComponentFactory setFactoryForResolvingUI:initialFactory];

--- a/Source/Factory/Assembly/TyphoonAssembly+TyphoonAssemblyFriend.h
+++ b/Source/Factory/Assembly/TyphoonAssembly+TyphoonAssemblyFriend.h
@@ -21,6 +21,8 @@
 
 - (NSArray *)definitions;
 
+- (NSArray *)preattachedInfrastructureComponents;
+
 - (TyphoonDefinition *)definitionForKey:(NSString *)key;
 
 - (Class)assemblyClassForKey:(NSString *)key;

--- a/Source/Factory/Assembly/TyphoonAssembly.m
+++ b/Source/Factory/Assembly/TyphoonAssembly.m
@@ -199,11 +199,18 @@ static NSMutableSet *reservedSelectorsAsStrings;
     [_factory makeDefault];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)attachPostProcessor:(id <TyphoonDefinitionPostProcessor>)postProcessor {
+    [self attachDefinitionPostProcessor:postProcessor];
+}
+#pragma clang diagnostic pop
+
+- (void)attachDefinitionPostProcessor:(id <TyphoonDefinitionPostProcessor>)definitionPostProcessor {
     if (!_factory) {
-        _preattachedInfrastructureComponents = [_preattachedInfrastructureComponents arrayByAddingObject:postProcessor];
+        [self preattachDefinitionPostProcessor:definitionPostProcessor];
     }
-    [_factory attachPostProcessor:postProcessor];
+    [_factory attachDefinitionPostProcessor:definitionPostProcessor];
 }
 
 - (id)objectForKeyedSubscript:(id)key {
@@ -332,6 +339,10 @@ static NSMutableSet *reservedSelectorsAsStrings;
     } else {
         return [self class];
     }
+}
+
+- (void)preattachDefinitionPostProcessor:(id <TyphoonDefinitionPostProcessor>)postProcessor {
+    _preattachedInfrastructureComponents = [_preattachedInfrastructureComponents arrayByAddingObject:postProcessor];
 }
 
 @end

--- a/Source/Factory/Assembly/TyphoonAssembly.m
+++ b/Source/Factory/Assembly/TyphoonAssembly.m
@@ -220,6 +220,13 @@ static NSMutableSet *reservedSelectorsAsStrings;
     [_factory attachInstancePostProcessor:postProcessor];
 }
 
+- (void)attachTypeConverter:(id<TyphoonTypeConverter>)typeConverter {
+    if (!_factory) {
+        [self preattachInfrastructureComponent:typeConverter];
+    }
+    [_factory attachTypeConverter:typeConverter];
+}
+
 - (id)objectForKeyedSubscript:(id)key {
     if (!_factory) {
         [NSException raise:NSInternalInconsistencyException

--- a/Source/Factory/Assembly/TyphoonAssembly.m
+++ b/Source/Factory/Assembly/TyphoonAssembly.m
@@ -31,6 +31,7 @@ static NSMutableSet *reservedSelectorsAsStrings;
 @interface TyphoonAssembly () <TyphoonObjectWithCustomInjection>
 
 @property(readwrite) NSSet *definitionSelectors;
+@property(readwrite) NSArray *preattachedInfrastructureComponents;
 
 @property(readwrite) NSDictionary *assemblyClassPerDefinitionKey;
 
@@ -123,6 +124,7 @@ static NSMutableSet *reservedSelectorsAsStrings;
         _definitionBuilder = [[TyphoonAssemblyDefinitionBuilder alloc] initWithAssembly:self];
         _adviser = [[TyphoonAssemblyAdviser alloc] initWithAssembly:self];
         _collector = [[TyphoonCollaboratingAssembliesCollector alloc] initWithAssemblyClass:[self class]];
+        _preattachedInfrastructureComponents = [NSArray array];
         
         [self proxyCollaboratingAssembliesPriorToActivation];
     }
@@ -199,8 +201,7 @@ static NSMutableSet *reservedSelectorsAsStrings;
 
 - (void)attachPostProcessor:(id <TyphoonDefinitionPostProcessor>)postProcessor {
     if (!_factory) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"attachPostProcessor: requires the assembly to be activated."];
+        _preattachedInfrastructureComponents = [_preattachedInfrastructureComponents arrayByAddingObject:postProcessor];
     }
     [_factory attachPostProcessor:postProcessor];
 }
@@ -332,6 +333,5 @@ static NSMutableSet *reservedSelectorsAsStrings;
         return [self class];
     }
 }
-
 
 @end

--- a/Source/Factory/Assembly/TyphoonAssembly.m
+++ b/Source/Factory/Assembly/TyphoonAssembly.m
@@ -206,11 +206,18 @@ static NSMutableSet *reservedSelectorsAsStrings;
 }
 #pragma clang diagnostic pop
 
-- (void)attachDefinitionPostProcessor:(id <TyphoonDefinitionPostProcessor>)definitionPostProcessor {
+- (void)attachDefinitionPostProcessor:(id <TyphoonDefinitionPostProcessor>)postProcessor {
     if (!_factory) {
-        [self preattachDefinitionPostProcessor:definitionPostProcessor];
+        [self preattachInfrastructureComponent:postProcessor];
     }
-    [_factory attachDefinitionPostProcessor:definitionPostProcessor];
+    [_factory attachDefinitionPostProcessor:postProcessor];
+}
+
+- (void)attachInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor {
+    if (!_factory) {
+        [self preattachInfrastructureComponent:postProcessor];
+    }
+    [_factory attachInstancePostProcessor:postProcessor];
 }
 
 - (id)objectForKeyedSubscript:(id)key {
@@ -341,8 +348,8 @@ static NSMutableSet *reservedSelectorsAsStrings;
     }
 }
 
-- (void)preattachDefinitionPostProcessor:(id <TyphoonDefinitionPostProcessor>)postProcessor {
-    _preattachedInfrastructureComponents = [_preattachedInfrastructureComponents arrayByAddingObject:postProcessor];
+- (void)preattachInfrastructureComponent:(id)component {
+    _preattachedInfrastructureComponents = [_preattachedInfrastructureComponents arrayByAddingObject:component];
 }
 
 @end

--- a/Source/Factory/Internal/TyphoonBlockComponentFactory.m
+++ b/Source/Factory/Internal/TyphoonBlockComponentFactory.m
@@ -105,7 +105,7 @@
             [self attachDefinitionPostProcessor:component];
         }
         else if ([component conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {
-            [self addInstancePostProcessor:component];
+            [self attachInstancePostProcessor:component];
         }
         else if ([component conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
             [self.typeConverterRegistry registerTypeConverter:component];

--- a/Source/Factory/Internal/TyphoonBlockComponentFactory.m
+++ b/Source/Factory/Internal/TyphoonBlockComponentFactory.m
@@ -108,7 +108,7 @@
             [self attachInstancePostProcessor:component];
         }
         else if ([component conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
-            [self.typeConverterRegistry registerTypeConverter:component];
+            [self attachTypeConverter:component];
         }
     }
 }

--- a/Source/Factory/Internal/TyphoonBlockComponentFactory.m
+++ b/Source/Factory/Internal/TyphoonBlockComponentFactory.m
@@ -61,7 +61,7 @@
 {
     self = [super init];
     if (self) {
-        [self attachPostProcessor:[TyphoonAssemblyPropertyInjectionPostProcessor new]];
+        [self attachDefinitionPostProcessor:[TyphoonAssemblyPropertyInjectionPostProcessor new]];
         for (TyphoonAssembly *assembly in assemblies) {
             [self buildAssembly:assembly];
         }
@@ -102,7 +102,7 @@
     
     for (id component in infrastructureComponents) {
         if ([component conformsToProtocol:@protocol(TyphoonDefinitionPostProcessor)]) {
-            [self attachPostProcessor:component];
+            [self attachDefinitionPostProcessor:component];
         }
         else if ([component conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {
             [self addInstancePostProcessor:component];

--- a/Source/Factory/Internal/TyphoonBlockComponentFactory.m
+++ b/Source/Factory/Internal/TyphoonBlockComponentFactory.m
@@ -22,6 +22,7 @@
 #import "TyphoonTypeConverter.h"
 #import "TyphoonInstancePostProcessor.h"
 #import "TyphoonComponentFactory+TyphoonDefinitionRegisterer.h"
+#import "TyphoonPreattachedComponentsRegisterer.h"
 
 @interface TyphoonComponentFactory (Private)
 
@@ -62,7 +63,10 @@
     self = [super init];
     if (self) {
         [self attachDefinitionPostProcessor:[TyphoonAssemblyPropertyInjectionPostProcessor new]];
+        TyphoonPreattachedComponentsRegisterer *preattachedComponentsRegisterer = [[TyphoonPreattachedComponentsRegisterer alloc] initWithComponentFactory:self];
+        
         for (TyphoonAssembly *assembly in assemblies) {
+            [preattachedComponentsRegisterer doRegistrationForAssembly:assembly];
             [self buildAssembly:assembly];
         }
     }
@@ -76,7 +80,6 @@
 
     [assembly prepareForUse];
 
-    [self registerAllPreattachedInfrastructureComponents:assembly];
     [self registerAllDefinitions:assembly];
 }
 
@@ -94,22 +97,6 @@
     NSArray *definitions = [assembly definitions];
     for (TyphoonDefinition *definition in definitions) {
         [self registerDefinition:definition];
-    }
-}
-
-- (void)registerAllPreattachedInfrastructureComponents:(TyphoonAssembly *)assembly {
-    NSArray *infrastructureComponents = [assembly preattachedInfrastructureComponents];
-    
-    for (id component in infrastructureComponents) {
-        if ([component conformsToProtocol:@protocol(TyphoonDefinitionPostProcessor)]) {
-            [self attachDefinitionPostProcessor:component];
-        }
-        else if ([component conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {
-            [self attachInstancePostProcessor:component];
-        }
-        else if ([component conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
-            [self attachTypeConverter:component];
-        }
     }
 }
 

--- a/Source/Factory/Internal/TyphoonComponentFactory+TyphoonDefinitionRegisterer.h
+++ b/Source/Factory/Internal/TyphoonComponentFactory+TyphoonDefinitionRegisterer.h
@@ -25,6 +25,6 @@
 
 - (void)addDefinitionToRegistry:(TyphoonDefinition *)definition;
 
-- (void)addInstancePostProcessor:(id <TyphoonInstancePostProcessor>)postProcessor;
+- (void)addInstancePostProcessor:(id <TyphoonInstancePostProcessor>)postProcessor DEPRECATED_MSG_ATTRIBUTE("use attachInstancePostProcessor instead");
 
 @end

--- a/Source/Factory/TyphoonComponentFactory.h
+++ b/Source/Factory/TyphoonComponentFactory.h
@@ -80,10 +80,12 @@
 - (void)makeDefault;
 
 /**
-Attach a TyphoonComponentFactoryPostProcessor to this component factory.
-@param postProcessor The post-processor to attach.
+Attach a TyphoonDefinitionPostProcessor to this component factory.
+@param definitionPostProcessor The definition post processor to attach.
 */
-- (void)attachPostProcessor:(id <TyphoonDefinitionPostProcessor>)postProcessor;
+- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)definitionPostProcessor;
+
+- (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor DEPRECATED_MSG_ATTRIBUTE("use  attachDefinitionPostProcessor instead");
 
 @end
 

--- a/Source/Factory/TyphoonComponentFactory.h
+++ b/Source/Factory/TyphoonComponentFactory.h
@@ -13,6 +13,7 @@
 
 #import <Foundation/Foundation.h>
 #import "TyphoonDefinitionPostProcessor.h"
+#import "TyphoonInstancePostProcessor.h"
 #import "TyphoonComponentsPool.h"
 
 @class TyphoonDefinition;
@@ -81,11 +82,17 @@
 
 /**
 Attach a TyphoonDefinitionPostProcessor to this component factory.
-@param definitionPostProcessor The definition post processor to attach.
+@param postProcessor The definition post processor to attach.
 */
-- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)definitionPostProcessor;
+- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor;
 
-- (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor DEPRECATED_MSG_ATTRIBUTE("use  attachDefinitionPostProcessor instead");
+/**
+ Attach a TyphoonInstancePostProcessor to this component factory.
+ @param postProcessor The instance post processor to attach.
+ */
+- (void)attachInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor;
+
+- (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor DEPRECATED_MSG_ATTRIBUTE("use attachDefinitionPostProcessor instead");
 
 @end
 

--- a/Source/Factory/TyphoonComponentFactory.h
+++ b/Source/Factory/TyphoonComponentFactory.h
@@ -14,6 +14,7 @@
 #import <Foundation/Foundation.h>
 #import "TyphoonDefinitionPostProcessor.h"
 #import "TyphoonInstancePostProcessor.h"
+#import "TyphoonTypeConverter.h"
 #import "TyphoonComponentsPool.h"
 
 @class TyphoonDefinition;
@@ -91,6 +92,12 @@ Attach a TyphoonDefinitionPostProcessor to this component factory.
  @param postProcessor The instance post processor to attach.
  */
 - (void)attachInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor;
+
+/**
+ Attach a TyphoonTypeConverter to this component factory.
+ @param typeConverter The type converter to attach.
+ */
+- (void)attachTypeConverter:(id<TyphoonTypeConverter>)typeConverter;
 
 - (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor DEPRECATED_MSG_ATTRIBUTE("use attachDefinitionPostProcessor instead");
 

--- a/Source/Factory/TyphoonComponentFactory.m
+++ b/Source/Factory/TyphoonComponentFactory.m
@@ -256,6 +256,11 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
     [_instancePostProcessors addObject:postProcessor];
 }
 
+- (void)attachTypeConverter:(id<TyphoonTypeConverter>)typeConverter {
+    LogTrace(@"Attaching type conveter: %@", typeConverter);
+    [_typeConverterRegistry registerTypeConverter:typeConverter];
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor

--- a/Source/Factory/TyphoonComponentFactory.m
+++ b/Source/Factory/TyphoonComponentFactory.m
@@ -242,13 +242,18 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
     }
 }
 
-- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)definitionPostProcessor {
-    LogTrace(@"Attaching definition post processor: %@", definitionPostProcessor);
-    [_definitionPostProcessors addObject:definitionPostProcessor];
+- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor {
+    LogTrace(@"Attaching definition post processor: %@", postProcessor);
+    [_definitionPostProcessors addObject:postProcessor];
     if ([self isLoaded]) {
         LogDebug(@"Definitions registered, refreshing all singletons.");
         [self unload];
     }
+}
+
+- (void)attachInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor {
+    LogTrace(@"Attaching instance post processor: %@", postProcessor);
+    [_instancePostProcessors addObject:postProcessor];
 }
 
 #pragma clang diagnostic push
@@ -463,10 +468,12 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
     [_registry addObject:definition];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)addInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor
 {
-    [_instancePostProcessors addObject:postProcessor];
+    [self attachInstancePostProcessor:postProcessor];
 }
-
+#pragma clang diagnostic pop
 
 @end

--- a/Source/Factory/TyphoonComponentFactory.m
+++ b/Source/Factory/TyphoonComponentFactory.m
@@ -79,9 +79,9 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
         _typeConverterRegistry = [[TyphoonTypeConverterRegistry alloc] init];
         _definitionPostProcessors = [[NSMutableArray alloc] init];
         _instancePostProcessors = [[NSMutableArray alloc] init];
-        [self attachPostProcessor:[TyphoonParentReferenceHydratingPostProcessor new]];
+        [self attachDefinitionPostProcessor:[TyphoonParentReferenceHydratingPostProcessor new]];
         [self attachAutoInjectionPostProcessorIfNeeded];
-        [self attachPostProcessor:[TyphoonFactoryPropertyInjectionPostProcessor new]];
+        [self attachDefinitionPostProcessor:[TyphoonFactoryPropertyInjectionPostProcessor new]];
     }
     return self;
 }
@@ -92,7 +92,7 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
 
     NSNumber *value = bundleInfoDictionary[@"TyphoonAutoInjectionEnabled"];
     if (!value || [value boolValue]) {
-        [self attachPostProcessor:[TyphoonFactoryAutoInjectionPostProcessor new]];
+        [self attachDefinitionPostProcessor:[TyphoonFactoryAutoInjectionPostProcessor new]];
     }
 }
 
@@ -242,17 +242,22 @@ static TyphoonComponentFactory *uiResolvingFactory = nil;
     }
 }
 
-
-- (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor
-{
-    LogTrace(@"Attaching post processor: %@", postProcessor);
-    [_definitionPostProcessors addObject:postProcessor];
+- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)definitionPostProcessor {
+    LogTrace(@"Attaching definition post processor: %@", definitionPostProcessor);
+    [_definitionPostProcessors addObject:definitionPostProcessor];
     if ([self isLoaded]) {
         LogDebug(@"Definitions registered, refreshing all singletons.");
         [self unload];
     }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (void)attachPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor
+{
+    [self attachDefinitionPostProcessor:postProcessor];
+}
+#pragma clang diagnostic pop
 
 - (void)inject:(id)instance
 {

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -93,7 +93,7 @@
 
     id infrastructureComponent = [_componentFactory newOrScopeCachedInstanceForDefinition:_definition args:nil];
     if ([_definition.type conformsToProtocol:@protocol(TyphoonDefinitionPostProcessor)]) {
-        [_componentFactory attachPostProcessor:infrastructureComponent];
+        [_componentFactory attachDefinitionPostProcessor:infrastructureComponent];
     }
     else if ([_definition.type conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {
         [_componentFactory addInstancePostProcessor:infrastructureComponent];

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -96,7 +96,7 @@
         [_componentFactory attachDefinitionPostProcessor:infrastructureComponent];
     }
     else if ([_definition.type conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {
-        [_componentFactory addInstancePostProcessor:infrastructureComponent];
+        [_componentFactory attachInstancePostProcessor:infrastructureComponent];
     }
     else if ([_definition.type conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
         [_componentFactory.typeConverterRegistry registerTypeConverter:infrastructureComponent];

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -99,7 +99,7 @@
         [_componentFactory attachInstancePostProcessor:infrastructureComponent];
     }
     else if ([_definition.type conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
-        [_componentFactory.typeConverterRegistry registerTypeConverter:infrastructureComponent];
+        [_componentFactory attachTypeConverter:infrastructureComponent];
     }
 }
 

--- a/Source/Factory/TyphoonPreattachedComponentsRegisterer.h
+++ b/Source/Factory/TyphoonPreattachedComponentsRegisterer.h
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@class TyphoonComponentFactory;
+@class TyphoonAssembly;
+
+@interface TyphoonPreattachedComponentsRegisterer : NSObject
+
+- (instancetype)initWithComponentFactory:(TyphoonComponentFactory *)componentFactory;
+
+- (void)doRegistrationForAssembly:(TyphoonAssembly *)assembly;
+
+@end

--- a/Source/Factory/TyphoonPreattachedComponentsRegisterer.m
+++ b/Source/Factory/TyphoonPreattachedComponentsRegisterer.m
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonPreattachedComponentsRegisterer.h"
+#import "TyphoonComponentFactory.h"
+#import "TyphoonAssembly+TyphoonAssemblyFriend.h"
+
+@interface TyphoonPreattachedComponentsRegisterer ()
+
+@property (strong, nonatomic) TyphoonComponentFactory *factory;
+
+@end
+
+@implementation TyphoonPreattachedComponentsRegisterer
+
+- (instancetype)initWithComponentFactory:(TyphoonComponentFactory *)componentFactory {
+    self = [super init];
+    if (self) {
+        _factory = componentFactory;
+    }
+    return self;
+}
+
+- (void)doRegistrationForAssembly:(TyphoonAssembly *)assembly {
+    NSArray *infrastructureComponents = [assembly preattachedInfrastructureComponents];
+    
+    for (id component in infrastructureComponents) {
+        if ([component conformsToProtocol:@protocol(TyphoonDefinitionPostProcessor)]) {
+            [self.factory attachDefinitionPostProcessor:component];
+        }
+        else if ([component conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {
+            [self.factory attachInstancePostProcessor:component];
+        }
+        else if ([component conformsToProtocol:@protocol(TyphoonTypeConverter)]) {
+            [self.factory attachTypeConverter:component];
+        }
+    }
+}
+
+@end

--- a/Tests/Factory/Assembly/TyphoonAssemblyTests.m
+++ b/Tests/Factory/Assembly/TyphoonAssemblyTests.m
@@ -19,6 +19,7 @@
 #import "OCLogTemplate.h"
 #import "TyphoonPatcher.h"
 #import "TyphoonInstancePostProcessorMock.h"
+#import "NSNullTypeConverter.h"
 
 @interface TyphoonAssemblyTests : XCTestCase
 @end
@@ -226,6 +227,9 @@
     TyphoonInstancePostProcessorMock *instancePostProcessor = [TyphoonInstancePostProcessorMock new];
     [assembly attachInstancePostProcessor:instancePostProcessor];
     
+    NSNullTypeConverter *typeConverter = [NSNullTypeConverter new];
+    [assembly attachTypeConverter:typeConverter];
+    
     TyphoonBlockComponentFactory *factory = [[TyphoonBlockComponentFactory alloc] initWithAssembly:assembly];
     
     NSArray *attachedDefinitionPostProcessors = factory.definitionPostProcessors;
@@ -234,8 +238,11 @@
     NSArray *attachedInstancePostProcessors = factory.instancePostProcessors;
     BOOL isInstancePostProcessorAttached = [attachedInstancePostProcessors containsObject:instancePostProcessor];
     
+    BOOL isTypeConverterAttached = [factory.typeConverterRegistry converterForType:[typeConverter supportedType]] != nil;
+    
     XCTAssertTrue(isPatcherAttached);
     XCTAssertTrue(isInstancePostProcessorAttached);
+    XCTAssertTrue(isTypeConverterAttached);
 }
 
 @end

--- a/Tests/Factory/Assembly/TyphoonAssemblyTests.m
+++ b/Tests/Factory/Assembly/TyphoonAssemblyTests.m
@@ -220,16 +220,11 @@
     MiddleAgesAssembly *assembly = [MiddleAgesAssembly assembly];
     
     TyphoonPatcher *patcher = [TyphoonPatcher new];
-    [assembly attachPostProcessor:patcher];
+    [assembly attachDefinitionPostProcessor:patcher];
     
     TyphoonBlockComponentFactory *factory = [[TyphoonBlockComponentFactory alloc] initWithAssembly:assembly];
     NSArray *attachedPostProcessors = factory.definitionPostProcessors;
-    BOOL isPatcherAttached = NO;
-    for (id postProcessor in attachedPostProcessors) {
-        if ([postProcessor isEqual:patcher]) {
-            isPatcherAttached = YES;
-        }
-    }
+    BOOL isPatcherAttached = [attachedPostProcessors containsObject:patcher];
     
     XCTAssertTrue(isPatcherAttached);
 }

--- a/Tests/Factory/Assembly/TyphoonAssemblyTests.m
+++ b/Tests/Factory/Assembly/TyphoonAssemblyTests.m
@@ -17,6 +17,7 @@
 #import "TyphoonLoopedCollaboratingAssemblies.h"
 #import "MediocreQuest.h"
 #import "OCLogTemplate.h"
+#import "TyphoonPatcher.h"
 
 @interface TyphoonAssemblyTests : XCTestCase
 @end
@@ -146,18 +147,6 @@
     }
 }
 
-- (void)test_before_activation_raises_exception_when_invoking_attachPostProcessor
-{
-    @try {
-        MiddleAgesAssembly *assembly = [MiddleAgesAssembly assembly];
-        [assembly attachPostProcessor:nil];
-        XCTFail(@"Should have thrown exception");
-    }
-    @catch (NSException *e) {
-        XCTAssertEqualObjects(@"attachPostProcessor: requires the assembly to be activated.", [e description]);
-    }
-}
-
 - (void)test_before_activation_raises_exception_when_invoking_subscription
 {
     @try {
@@ -224,6 +213,25 @@
     @catch (NSException *e) {
         XCTAssertNil(e);
     }
+}
+
+- (void)test_before_activation_stores_post_processors
+{
+    MiddleAgesAssembly *assembly = [MiddleAgesAssembly assembly];
+    
+    TyphoonPatcher *patcher = [TyphoonPatcher new];
+    [assembly attachPostProcessor:patcher];
+    
+    TyphoonBlockComponentFactory *factory = [[TyphoonBlockComponentFactory alloc] initWithAssembly:assembly];
+    NSArray *attachedPostProcessors = factory.definitionPostProcessors;
+    BOOL isPatcherAttached = NO;
+    for (id postProcessor in attachedPostProcessors) {
+        if ([postProcessor isEqual:patcher]) {
+            isPatcherAttached = YES;
+        }
+    }
+    
+    XCTAssertTrue(isPatcherAttached);
 }
 
 @end

--- a/Tests/Factory/Assembly/TyphoonAssemblyTests.m
+++ b/Tests/Factory/Assembly/TyphoonAssemblyTests.m
@@ -18,6 +18,7 @@
 #import "MediocreQuest.h"
 #import "OCLogTemplate.h"
 #import "TyphoonPatcher.h"
+#import "TyphoonInstancePostProcessorMock.h"
 
 @interface TyphoonAssemblyTests : XCTestCase
 @end
@@ -215,18 +216,26 @@
     }
 }
 
-- (void)test_before_activation_stores_post_processors
+- (void)test_before_activation_preattaches_infrastructure_components
 {
     MiddleAgesAssembly *assembly = [MiddleAgesAssembly assembly];
     
     TyphoonPatcher *patcher = [TyphoonPatcher new];
     [assembly attachDefinitionPostProcessor:patcher];
     
+    TyphoonInstancePostProcessorMock *instancePostProcessor = [TyphoonInstancePostProcessorMock new];
+    [assembly attachInstancePostProcessor:instancePostProcessor];
+    
     TyphoonBlockComponentFactory *factory = [[TyphoonBlockComponentFactory alloc] initWithAssembly:assembly];
-    NSArray *attachedPostProcessors = factory.definitionPostProcessors;
-    BOOL isPatcherAttached = [attachedPostProcessors containsObject:patcher];
+    
+    NSArray *attachedDefinitionPostProcessors = factory.definitionPostProcessors;
+    BOOL isPatcherAttached = [attachedDefinitionPostProcessors containsObject:patcher];
+    
+    NSArray *attachedInstancePostProcessors = factory.instancePostProcessors;
+    BOOL isInstancePostProcessorAttached = [attachedInstancePostProcessors containsObject:instancePostProcessor];
     
     XCTAssertTrue(isPatcherAttached);
+    XCTAssertTrue(isInstancePostProcessorAttached);
 }
 
 @end

--- a/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
+++ b/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
@@ -56,7 +56,7 @@
     internalProcessorsCount = [[_componentFactory definitionPostProcessors] count];
 
     TyphoonConfigPostProcessor *processor = [TyphoonConfigPostProcessor forResourceNamed:@"SomeProperties.properties"];
-    [_componentFactory attachPostProcessor:processor];
+    [_componentFactory attachDefinitionPostProcessor:processor];
 
     _exceptionTestFactory = [[TyphoonBlockComponentFactory alloc] initWithAssembly:[ExceptionTestAssembly assembly]];
     _circularDependenciesFactory = [[TyphoonBlockComponentFactory alloc]
@@ -217,7 +217,7 @@
     TyphoonComponentFactory *factory = [[TyphoonBlockComponentFactory alloc]
         initWithAssembly:[TyphoonConfigAssembly assembly]];
     TyphoonConfigPostProcessor *processor = [TyphoonConfigPostProcessor forResourceNamed:@"SomeProperties.properties"];
-    [factory attachPostProcessor:processor];
+    [factory attachDefinitionPostProcessor:processor];
 
     Knight *knight = [factory componentForKey:@"knight"];
     XCTAssertEqual(knight.damselsRescued, (NSUInteger)12);

--- a/Tests/Factory/TyphoonComponentFactoryTests.m
+++ b/Tests/Factory/TyphoonComponentFactoryTests.m
@@ -225,9 +225,9 @@ static NSString *const DEFAULT_QUEST = @"quest";
     TyphoonInstancePostProcessorMock*processor1 = [[TyphoonInstancePostProcessorMock alloc] initWithOrder:INT_MAX];
     TyphoonInstancePostProcessorMock*processor2 = [[TyphoonInstancePostProcessorMock alloc] initWithOrder:0];
     TyphoonInstancePostProcessorMock*processor3 = [[TyphoonInstancePostProcessorMock alloc] initWithOrder:INT_MIN];
-    [_componentFactory addInstancePostProcessor:processor1];
-    [_componentFactory addInstancePostProcessor:processor2];
-    [_componentFactory addInstancePostProcessor:processor3];
+    [_componentFactory attachInstancePostProcessor:processor1];
+    [_componentFactory attachInstancePostProcessor:processor2];
+    [_componentFactory attachInstancePostProcessor:processor3];
     [_componentFactory registerDefinition:[TyphoonDefinition withClass:[Knight class]]];
 
     __block NSMutableArray *orderedApplied = [[NSMutableArray alloc] initWithCapacity:3];

--- a/Tests/Test/Patcher/TyphoonPatcherTests.m
+++ b/Tests/Test/Patcher/TyphoonPatcherTests.m
@@ -121,7 +121,7 @@
         return knight;
     }];
 
-    [_assembly attachPostProcessor:_patcher];
+    [_assembly attachDefinitionPostProcessor:_patcher];
 }
 
 - (void)assertPatchApplied

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -538,6 +538,10 @@
 		9F0F25331BEA2845002AD880 /* TyphoonNSColorTypeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0F25241BEA2327002AD880 /* TyphoonNSColorTypeConverter.h */; };
 		9F0F25341BEA2859002AD880 /* TyphoonColorConversionUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0F252E1BEA2571002AD880 /* TyphoonColorConversionUtils.h */; };
 		9F0F25351BEA37B0002AD880 /* TyphoonTypeConversionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0F25131BEA1267002AD880 /* TyphoonTypeConversionUtils.m */; };
+		9F1187A11BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */; };
+		9F1187A21BEE2521008859E0 /* TyphoonPreattachedComponentsRegisterer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F11879F1BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.h */; };
+		9F1187A31BEE2536008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */; };
+		9F1187A41BEE253E008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -1104,6 +1108,8 @@
 		9F0F252A1BEA23E6002AD880 /* TyphoonNSColorTypeConverterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonNSColorTypeConverterTests.m; path = Tests/OSX/TypeConversion/TyphoonNSColorTypeConverterTests.m; sourceTree = SOURCE_ROOT; };
 		9F0F252E1BEA2571002AD880 /* TyphoonColorConversionUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonColorConversionUtils.h; path = Helpers/TyphoonColorConversionUtils.h; sourceTree = "<group>"; };
 		9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonColorConversionUtils.m; path = Helpers/TyphoonColorConversionUtils.m; sourceTree = "<group>"; };
+		9F11879F1BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonPreattachedComponentsRegisterer.h; sourceTree = "<group>"; };
+		9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonPreattachedComponentsRegisterer.m; sourceTree = "<group>"; };
 		9F2C08A61BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonCollaboratingAssembliesCollector.h; sourceTree = "<group>"; };
 		9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollector.m; sourceTree = "<group>"; };
 		9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollectorTests.m; sourceTree = "<group>"; };
@@ -1547,6 +1553,8 @@
 				6B076F491936F63A0083714E /* TyphoonComponentFactory.m */,
 				6B076F4A1936F63A0083714E /* TyphoonDefinitionRegisterer.h */,
 				6B076F4B1936F63A0083714E /* TyphoonDefinitionRegisterer.m */,
+				9F11879F1BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.h */,
+				9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */,
 			);
 			path = Factory;
 			sourceTree = "<group>";
@@ -2562,6 +2570,7 @@
 				BA79830373597A7AA358C2D8 /* TyphoonCollaboratingAssemblyProxy.h in Headers */,
 				9F0591E11BE88408007CCB9C /* TyphoonStoryboardProvider.h in Headers */,
 				9F0591E01BE88404007CCB9C /* TyphoonViewHelpers.h in Headers */,
+				9F1187A21BEE2521008859E0 /* TyphoonPreattachedComponentsRegisterer.h in Headers */,
 				BA798EB0684A45DDBA818962 /* TyphoonBlockComponentFactory.h in Headers */,
 				BA79808B1AE811F764E7B14F /* TyphoonCircularDependencyTerminator.h in Headers */,
 				BA798A97C60EC12681B6AAF4 /* TyphoonAssemblyDefinitionBuilder.h in Headers */,
@@ -2908,6 +2917,7 @@
 				6B0770A41936F9000083714E /* TyphoonInjectionByCollection.m in Sources */,
 				6B0770A51936F9000083714E /* TyphoonInjectionByComponentFactory.m in Sources */,
 				9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */,
+				9F1187A11BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */,
 				6B0770A61936F9000083714E /* TyphoonInjectionByConfig.m in Sources */,
 				6B0770A71936F9000083714E /* TyphoonInjectionByDictionary.m in Sources */,
 				6B0770A81936F9000083714E /* TyphoonInjectionByFactoryReference.m in Sources */,
@@ -3142,6 +3152,7 @@
 				6B0773B51937831B0083714E /* TyphoonAssembly.m in Sources */,
 				6B0773BF1937831B0083714E /* NSInvocation+TCFInstanceBuilder.m in Sources */,
 				6B0773C01937831B0083714E /* NSInvocation+TCFUnwrapValues.m in Sources */,
+				9F1187A31BEE2536008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */,
 				6B0773C11937831B0083714E /* NSMethodSignature+TCFUnwrapValues.m in Sources */,
 				6B0773C21937831B0083714E /* NSValue+TCFUnwrapValues.m in Sources */,
 				6B0773C31937831B0083714E /* TyphoonCallStack.m in Sources */,
@@ -3318,6 +3329,7 @@
 				90ABC4051A36B1B4008D8162 /* TyphoonOptionMatcher.m in Sources */,
 				90ABC4061A36B1B4008D8162 /* TyphoonDefinition+Option.m in Sources */,
 				90ABC4071A36B1B4008D8162 /* TyphoonConfigPostProcessor.m in Sources */,
+				9F1187A41BEE253E008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */,
 				90ABC4081A36B1B4008D8162 /* TyphoonJsonStyleConfiguration.m in Sources */,
 				90ABC4091A36B1B4008D8162 /* TyphoonPlistStyleConfiguration.m in Sources */,
 				90ABC40A1A36B1B4008D8162 /* TyphoonPropertyStyleConfiguration.m in Sources */,


### PR DESCRIPTION
This PR relates to issue #344. The user can now pre-attach infrastructure components to the non-activated assembly. These components are:

- `TyphoonDefinitionPostProcessor's`
- `TyphoonInstancePostProcessors`
- `TyphoonTypeConverters`

When the assembly will be activated these components would be attached to the underlying `TyphoonComponentFactory`.

The following methods are deprecated:
- `[TyphoonComponentFactory attachPostProcessor]`
- `[TyphoonComponentFactory addInstancePostProcessor]`