### PR TITLE
Namespacing for TyphoonDefinitions and TyphoonConfigPostProcessors

### DIFF
--- a/Source/Configuration/ConfigPostProcessor/TyphoonConfigPostProcessor.h
+++ b/Source/Configuration/ConfigPostProcessor/TyphoonConfigPostProcessor.h
@@ -14,6 +14,7 @@
 #import "TyphoonDefinitionPostProcessor.h"
 
 @protocol TyphoonResource;
+@class TyphoonDefinitionNamespace;
 
 /**
 * @ingroup Configuration
@@ -38,7 +39,6 @@
 */
 + (instancetype)forResourceAtPath:(NSString *)path;
 
-
 /**
 *  You can manage TyphoonConfigPostProcessor registry by mapping configuration classes for file extensions
 *  Configuration class instance must conforms TyphoonConfiguration protocol
@@ -48,6 +48,8 @@
 /** list of all supported path extensions (configuration types) */
 + (NSArray *)availableExtensions;
 
+/** Registers a namespace for this config post processor */
+- (void)registerNamespace:(TyphoonDefinitionNamespace *)space;
 
 /** Append resource found in main bundle by name */
 - (void)useResourceWithName:(NSString *)name;

--- a/Source/Configuration/GlobalConfigResolver/TyphoonGlobalConfigCollector.h
+++ b/Source/Configuration/GlobalConfigResolver/TyphoonGlobalConfigCollector.h
@@ -1,0 +1,20 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonGlobalConfigCollector : NSObject
+
+- (instancetype)initWithAppDelegate:(id)appDelegate;
+
+- (NSArray *)obtainGlobalConfigFilenamesFromBundle:(NSBundle *)bundle;
+
+@end

--- a/Source/Configuration/GlobalConfigResolver/TyphoonGlobalConfigCollector.m
+++ b/Source/Configuration/GlobalConfigResolver/TyphoonGlobalConfigCollector.m
@@ -1,0 +1,91 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonGlobalConfigCollector.h"
+
+@interface TyphoonGlobalConfigCollector ()
+
+@property (strong, nonatomic) id appDelegate;
+
+@end
+
+@implementation TyphoonGlobalConfigCollector
+
+- (instancetype)initWithAppDelegate:(id)appDelegate {
+    self = [super init];
+    if (self) {
+        _appDelegate = appDelegate;
+    }
+    return self;
+}
+
+- (NSArray *)obtainGlobalConfigFilenamesFromBundle:(NSBundle *)bundle {
+    NSArray *plistFilenames = [self fetchConfigFilenamesFromPlistKeyInBundle:bundle];
+    NSArray *appDelegateFilenames = [self fetchConfigFilenamesFromAppDelegate];
+    NSString *bundleIdFilename = [self fetchConfigFilenameFromUniqueBundleIdInBundle:bundle];
+    NSString *oldStylePlistFilename = [self fetchConfigFilenameFromOldStylePlistKeyInBundle:bundle];
+    
+    NSMutableSet *resultNames = [NSMutableSet set];
+    if (plistFilenames) {
+        [resultNames addObjectsFromArray:plistFilenames];
+    }
+    
+    if (appDelegateFilenames) {
+        [resultNames addObjectsFromArray:appDelegateFilenames];
+    }
+    
+    if (bundleIdFilename) {
+        [resultNames addObject:bundleIdFilename];
+    }
+    
+    if (oldStylePlistFilename) {
+        [resultNames addObject:oldStylePlistFilename];
+    }
+    
+    return [resultNames allObjects];
+}
+
+- (NSArray *)fetchConfigFilenamesFromPlistKeyInBundle:(NSBundle *)bundle {
+    NSArray *fileNames = [bundle infoDictionary][@"TyphoonGlobalConfigFilenames"];
+    return fileNames;
+}
+
+- (NSArray *)fetchConfigFilenamesFromAppDelegate {
+    NSArray *fileNames;
+    SEL globalConfigFilenamesSelector = NSSelectorFromString(@"globalConfigFilenames");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    if ([self.appDelegate respondsToSelector:globalConfigFilenamesSelector]) {
+        fileNames = [self.appDelegate performSelector:globalConfigFilenamesSelector];
+    }
+#pragma clang diagnostic pop
+    return fileNames;
+}
+
+- (NSString *)fetchConfigFilenameFromOldStylePlistKeyInBundle:(NSBundle *)bundle {
+    NSString *configFileName = [bundle infoDictionary][@"TyphoonConfigFilename"];
+    return configFileName;
+}
+
+- (NSString *)fetchConfigFilenameFromUniqueBundleIdInBundle:(NSBundle *)bundle {
+    NSString *fileName = nil;
+    
+    NSString *bundleID = [bundle infoDictionary][@"CFBundleIdentifier"];
+    NSString *configFilename = [NSString stringWithFormat:@"config_%@.plist", bundleID];
+    NSString *configPath = [[bundle resourcePath] stringByAppendingPathComponent:configFilename];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:configPath]) {
+        fileName = configFilename;
+    }
+    
+    return fileName;
+}
+
+@end

--- a/Source/Configuration/Startup/TyphoonStartup.m
+++ b/Source/Configuration/Startup/TyphoonStartup.m
@@ -19,6 +19,7 @@
 #import "OCLogTemplate.h"
 #import "TyphoonAssemblyBuilder+PlistProcessor.h"
 #import "TyphoonAssemblyBuilder.h"
+#import "TyphoonGlobalConfigCollector.h"
 
 #import <objc/runtime.h>
 
@@ -82,26 +83,6 @@ static BOOL initialFactoryWasCreated = NO;
     initialFactoryRequestCount += 1;
 }
 
-+ (id<TyphoonDefinitionPostProcessor>)configPostProcessor
-{
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    NSString *fileName = [bundle infoDictionary][@"TyphoonConfigFilename"];
-    if (![fileName length]) {
-        NSString *bundleID = [bundle infoDictionary][@"CFBundleIdentifier"];
-        NSString *configFilename = [NSString stringWithFormat:@"config_%@.plist", bundleID];
-        NSString *configPath = [[bundle resourcePath] stringByAppendingPathComponent:configFilename];
-        if ([[NSFileManager defaultManager] fileExistsAtPath:configPath]) {
-            fileName = configFilename;
-        }
-    }
-    id<TyphoonDefinitionPostProcessor> configProcessor = nil;
-    if ([fileName length]) {
-        configProcessor = [TyphoonConfigPostProcessor forResourceNamed:fileName];
-    }
-    return configProcessor;
-}
-
-
 + (TyphoonComponentFactory *)initialFactory
 {
     return initialFactory;
@@ -127,10 +108,14 @@ static BOOL initialFactoryWasCreated = NO;
             initialFactory = factoryFromDelegate;
         }
         if (initialFactory) {
-            id<TyphoonDefinitionPostProcessor> processor = [self configPostProcessor];
-            if (processor) {
-                [initialFactory attachDefinitionPostProcessor:processor];
+            TyphoonGlobalConfigCollector *collector = [[TyphoonGlobalConfigCollector alloc] initWithAppDelegate:delegate];
+            NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+            NSArray *globalConfigFileNames = [collector obtainGlobalConfigFilenamesFromBundle:bundle];
+            for (NSString *configName in globalConfigFileNames) {
+                id<TyphoonDefinitionPostProcessor> configProcessor = [TyphoonConfigPostProcessor forResourceNamed:configName inBundle:bundle];
+                [initialFactory attachDefinitionPostProcessor:configProcessor];
             }
+
             [self injectInitialFactoryIntoDelegate:delegate];
             [TyphoonComponentFactory setFactoryForResolvingUI:initialFactory];
         }

--- a/Source/Definition/Injections/TyphoonInjectionByConfig.m
+++ b/Source/Definition/Injections/TyphoonInjectionByConfig.m
@@ -27,6 +27,10 @@
     return self;
 }
 
+- (void)setConfiguredInjection:(id<TyphoonInjection>)configuredInjection {
+    _configuredInjection = configuredInjection;
+}
+
 - (id)copyWithZone:(NSZone *)zone
 {
     TyphoonInjectionByConfig *copied = [[TyphoonInjectionByConfig alloc] initWithConfigKey:self.configKey];

--- a/Source/Definition/Internal/TyphoonDefinition+Infrastructure.h
+++ b/Source/Definition/Internal/TyphoonDefinition+Infrastructure.h
@@ -63,7 +63,7 @@ Factory method for a TyphoonConfigPostProcessor. Don't use it in test targets!
 @param fileName The config filename to load. File should be placed in main bundle
 @return a definition.
 */
-+ (instancetype)configDefinitionWithName:(NSString *)fileName;
++ (instancetype)withConfigName:(NSString *)fileName;
 
 /**
  Factory method for a TyphoonConfigPostProcessor.
@@ -71,18 +71,23 @@ Factory method for a TyphoonConfigPostProcessor. Don't use it in test targets!
  @param fileBundle  The bundle, where the config file is placed
  @return a definition.
  */
-+ (instancetype)configDefinitionWithName:(NSString *)fileName bundle:(NSBundle *)fileBundle;
++ (instancetype)withConfigName:(NSString *)fileName bundle:(NSBundle *)fileBundle;
 
 /**
 Factory method for a TyphoonConfigPostProcessor.
 @param filePath The path to config file to load.
 @return a definition.
 */
-+ (instancetype)configDefinitionWithPath:(NSString *)filePath;
++ (instancetype)withConfigPath:(NSString *)filePath;
 
 - (BOOL)isCandidateForInjectedClass:(Class)clazz includeSubclasses:(BOOL)includeSubclasses;
 
 - (BOOL)isCandidateForInjectedProtocol:(Protocol *)aProtocol;
 
+#pragma mark - Deprecated methods
+
++ (instancetype)configDefinitionWithName:(NSString *)fileName DEPRECATED_MSG_ATTRIBUTE("use attachInstancePostProcessor instead");
++ (instancetype)configDefinitionWithName:(NSString *)fileName bundle:(NSBundle *)fileBundle DEPRECATED_MSG_ATTRIBUTE("use attachInstancePostProcessor instead");
++ (instancetype)configDefinitionWithPath:(NSString *)filePath DEPRECATED_MSG_ATTRIBUTE("use attachInstancePostProcessor instead");
 
 @end

--- a/Source/Definition/Internal/TyphoonDefinition+Infrastructure.m
+++ b/Source/Definition/Internal/TyphoonDefinition+Infrastructure.m
@@ -15,6 +15,7 @@
 TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
 
 #import "TyphoonDefinition+Infrastructure.h"
+#import "TyphoonDefinition+Namespacing.h"
 #import "TyphoonConfigPostProcessor.h"
 #import "TyphoonResource.h"
 #import "TyphoonMethod.h"
@@ -98,16 +99,22 @@ TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
 
 + (instancetype)configDefinitionWithName:(NSString *)fileName
 {
-    return [self withConfigName:fileName];
+    TyphoonDefinition *configDefinition = [self withConfigName:fileName];
+    [configDefinition applyGlobalNamespace];
+    return configDefinition;
 }
 
 + (instancetype)configDefinitionWithName:(NSString *)fileName bundle:(NSBundle *)fileBundle {
-    return [self withConfigName:fileName bundle:fileBundle];
+    TyphoonDefinition *configDefinition = [self withConfigName:fileName bundle:fileBundle];
+    [configDefinition applyGlobalNamespace];
+    return configDefinition;
 }
 
 + (instancetype)configDefinitionWithPath:(NSString *)filePath
 {
-    return [self withConfigPath:filePath];
+    TyphoonDefinition *configDefinition = [self withConfigPath:filePath];
+    [configDefinition applyGlobalNamespace];
+    return configDefinition;
 }
 
 @end

--- a/Source/Definition/Internal/TyphoonDefinition+Infrastructure.m
+++ b/Source/Definition/Internal/TyphoonDefinition+Infrastructure.m
@@ -35,8 +35,7 @@ TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
     return [[TyphoonDefinition alloc] initWithClass:clazz key:key];
 }
 
-+ (instancetype)configDefinitionWithName:(NSString *)fileName
-{
++ (instancetype)withConfigName:(NSString *)fileName {
     return [self withClass:[TyphoonConfigPostProcessor class] configuration:^(TyphoonDefinition *definition) {
         [definition injectMethod:@selector(useResourceWithName:) parameters:^(TyphoonMethod *method) {
             [method injectParameterWith:fileName];
@@ -45,7 +44,7 @@ TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
     }];
 }
 
-+ (instancetype)configDefinitionWithName:(NSString *)fileName bundle:(NSBundle *)fileBundle {
++ (instancetype)withConfigName:(NSString *)fileName bundle:(NSBundle *)fileBundle {
     return [self withClass:[TyphoonConfigPostProcessor class] configuration:^(TyphoonDefinition *definition) {
         [definition injectMethod:@selector(useResourceWithName:bundle:) parameters:^(TyphoonMethod *method) {
             [method injectParameterWith:fileName];
@@ -55,8 +54,7 @@ TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
     }];
 }
 
-+ (instancetype)configDefinitionWithPath:(NSString *)filePath
-{
++ (instancetype)withConfigPath:(NSString *)filePath {
     return [self withClass:[TyphoonConfigPostProcessor class] configuration:^(TyphoonDefinition *definition) {
         [definition injectMethod:@selector(useResourceAtPath:) parameters:^(TyphoonMethod *method) {
             [method injectParameterWith:filePath];
@@ -86,7 +84,6 @@ TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
 
 }
 
-
 - (void)setProcessed:(BOOL)processed
 {
     _processed = processed;
@@ -95,6 +92,22 @@ TYPHOON_LINK_CATEGORY(TyphoonDefinition_Infrastructure)
 - (BOOL)processed
 {
     return _processed;
+}
+
+#pragma mark - Deprecated methods
+
++ (instancetype)configDefinitionWithName:(NSString *)fileName
+{
+    return [self withConfigName:fileName];
+}
+
++ (instancetype)configDefinitionWithName:(NSString *)fileName bundle:(NSBundle *)fileBundle {
+    return [self withConfigName:fileName bundle:fileBundle];
+}
+
++ (instancetype)configDefinitionWithPath:(NSString *)filePath
+{
+    return [self withConfigPath:filePath];
 }
 
 @end

--- a/Source/Definition/Namespacing/TyphoonDefinition+Namespacing.h
+++ b/Source/Definition/Namespacing/TyphoonDefinition+Namespacing.h
@@ -1,0 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Typhoon/Typhoon.h>
+
+#import "TyphoonDefinitionNamespace.h"
+
+@interface TyphoonDefinition (Namespacing)
+
+- (void)applyGlobalNamespace;
+
+- (void)applyConcreteNamespace:(NSString *)key;
+
+@end

--- a/Source/Definition/Namespacing/TyphoonDefinition+Namespacing.m
+++ b/Source/Definition/Namespacing/TyphoonDefinition+Namespacing.m
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonDefinition+Namespacing.h"
+
+@interface TyphoonDefinition ()
+
+@property (nonatomic, strong) TyphoonDefinitionNamespace *space;
+
+@end
+
+@implementation TyphoonDefinition (Namespacing)
+
+- (void)applyGlobalNamespace {
+    TyphoonDefinitionNamespace *namespace = [TyphoonDefinitionNamespace globalNamespace];
+    _space = namespace;
+}
+
+- (void)applyConcreteNamespace:(NSString *)key {
+    TyphoonDefinitionNamespace *namespace = [TyphoonDefinitionNamespace namespaceWithKey:key];
+    _space = namespace;
+}
+
+@end

--- a/Source/Definition/Namespacing/TyphoonDefinitionNamespace.h
+++ b/Source/Definition/Namespacing/TyphoonDefinitionNamespace.h
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonDefinitionNamespace : NSObject
+
++ (instancetype)namespaceWithKey:(NSString *)key;
++ (instancetype)globalNamespace;
+
+@property (strong, nonatomic, readonly) NSString *key;
+
+@end

--- a/Source/Definition/Namespacing/TyphoonDefinitionNamespace.h
+++ b/Source/Definition/Namespacing/TyphoonDefinitionNamespace.h
@@ -18,4 +18,6 @@
 
 @property (strong, nonatomic, readonly) NSString *key;
 
+- (BOOL)isGlobalNamespace;
+
 @end

--- a/Source/Definition/Namespacing/TyphoonDefinitionNamespace.m
+++ b/Source/Definition/Namespacing/TyphoonDefinitionNamespace.m
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonDefinitionNamespace.h"
+
+static NSString *const TyphoonDefinitionGlobalNamespace = @"TyphoonDefinitionGlobalNamespace";
+
+@interface TyphoonDefinitionNamespace ()
+
+@property (strong, nonatomic, readwrite) NSString *key;
+
+@end
+
+@implementation TyphoonDefinitionNamespace
+
++ (instancetype)globalNamespace {
+    return [self namespaceWithKey:TyphoonDefinitionGlobalNamespace];
+}
+
++ (instancetype)namespaceWithKey:(NSString *)key {
+    return [[[self class] alloc] initWithKey:key];
+}
+
+- (instancetype)initWithKey:(NSString *)key {
+    self = [super init];
+    if (self) {
+        _key = key;
+    }
+    return self;
+}
+
+- (NSUInteger)hash
+{
+    return [self.key hash];
+}
+
+- (BOOL)isEqual:(id)other
+{
+    if (other == self) {
+        return YES;
+    }
+    if (!other || ![[other class] isEqual:[self class]]) {
+        return NO;
+    }
+    
+    return [self.key isEqualToString:((TyphoonDefinitionNamespace *)other).key];
+}
+
+@end

--- a/Source/Definition/Namespacing/TyphoonDefinitionNamespace.m
+++ b/Source/Definition/Namespacing/TyphoonDefinitionNamespace.m
@@ -37,6 +37,10 @@ static NSString *const TyphoonDefinitionGlobalNamespace = @"TyphoonDefinitionGlo
     return self;
 }
 
+- (BOOL)isGlobalNamespace {
+    return [self.key isEqualToString:TyphoonDefinitionGlobalNamespace];
+}
+
 - (NSUInteger)hash
 {
     return [self.key hash];

--- a/Source/Definition/TyphoonDefinition.h
+++ b/Source/Definition/TyphoonDefinition.h
@@ -17,6 +17,7 @@
 @class TyphoonDefinition;
 @class TyphoonRuntimeArguments;
 @class TyphoonFactoryDefinition;
+@class TyphoonDefinitionNamespace;
 
 /**
 * @ingroup Definition
@@ -69,6 +70,7 @@ typedef void(^TyphoonDefinitionBlock)(TyphoonDefinition *definition);
 {
     Class _type;
     NSString *_key;
+    TyphoonDefinitionNamespace *_space;
     BOOL _processed;
 
     TyphoonMethod *_initializer;
@@ -112,7 +114,6 @@ typedef void(^TyphoonDefinitionBlock)(TyphoonDefinition *definition);
 * InjectedClass or InjectedProtocol marco
 */
 @property(nonatomic) TyphoonAutoInjectVisibility autoInjectionVisibility;
-
 
 /**
 * A parent component. When parent is defined the initializer and/or properties from a definition are inherited, unless overridden. Example:

--- a/Source/Definition/TyphoonDefinition.h
+++ b/Source/Definition/TyphoonDefinition.h
@@ -13,11 +13,11 @@
 #import <Foundation/Foundation.h>
 
 #import "TyphoonMethod.h"
+#import "TyphoonDefinitionNamespace.h"
 
 @class TyphoonDefinition;
 @class TyphoonRuntimeArguments;
 @class TyphoonFactoryDefinition;
-@class TyphoonDefinitionNamespace;
 
 /**
 * @ingroup Definition
@@ -104,6 +104,11 @@ typedef void(^TyphoonDefinitionBlock)(TyphoonDefinition *definition);
 * The scope of the component, default being TyphoonScopeObjectGraph.
 */
 @property(nonatomic) TyphoonScope scope;
+
+/**
+ * The namespace of the component&
+ */
+@property(nonatomic, readonly) TyphoonDefinitionNamespace *space;
 
 /**
 * Specifies visibility for for AutoInjection.

--- a/Source/Factory/Internal/TyphoonAssemblyDefinitionBuilder.m
+++ b/Source/Factory/Internal/TyphoonAssemblyDefinitionBuilder.m
@@ -23,6 +23,7 @@
 #import "TyphoonUtils.h"
 #import "TyphoonRuntimeArguments.h"
 #import "TyphoonReferenceDefinition.h"
+#import "TyphoonDefinition+Namespacing.h"
 
 #import <objc/runtime.h>
 
@@ -86,6 +87,7 @@ static void AssertArgumentType(id target, SEL selector, const char *argumentType
     if ([cached isKindOfClass:[TyphoonDefinition class]]) {
         /* Set current runtime args to know passed arguments when build definition */
         ((TyphoonDefinition *) cached).currentRuntimeArguments = args;
+        [((TyphoonDefinition *) cached) applyConcreteNamespace:NSStringFromClass([self.assembly class])];
     }
 
     LogTrace(@"Did finish building definition for key: '%@'", key);

--- a/Source/Factory/Internal/TyphoonComponentFactory+InstanceBuilder.m
+++ b/Source/Factory/Internal/TyphoonComponentFactory+InstanceBuilder.m
@@ -26,6 +26,7 @@ TYPHOON_LINK_CATEGORY(TyphoonComponentFactory_InstanceBuilder)
 #import "TyphoonPropertyInjection.h"
 #import "NSObject+TyphoonIntrospectionUtils.h"
 #import "TyphoonFactoryAutoInjectionPostProcessor.h"
+#import "TyphoonDefinition+Namespacing.h"
 
 @implementation TyphoonComponentFactory (InstanceBuilder)
 
@@ -277,6 +278,7 @@ TYPHOON_LINK_CATEGORY(TyphoonComponentFactory_InstanceBuilder)
         for (id propertyInjection in properties) {
             [result addInjectedPropertyIfNotExists:propertyInjection];
         }
+        [result applyGlobalNamespace];
     }
 
     return result;

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -24,6 +24,7 @@
 #import "TyphoonMethod+InstanceBuilder.h"
 #import "TyphoonIntrospectionUtils.h"
 #import "TyphoonDefinition+Infrastructure.h"
+#import "TyphoonConfigPostProcessor.h"
 
 @implementation TyphoonDefinitionRegisterer
 {
@@ -92,7 +93,11 @@
     LogTrace(@"Registering Infrastructure component: %@ with key: %@", NSStringFromClass(_definition.type), _definition.key);
 
     id infrastructureComponent = [_componentFactory newOrScopeCachedInstanceForDefinition:_definition args:nil];
-    if ([_definition.type conformsToProtocol:@protocol(TyphoonDefinitionPostProcessor)]) {
+    if (_definition.type == [TyphoonConfigPostProcessor class]) {
+        [infrastructureComponent registerNamespace:_definition.space];
+        [_componentFactory attachDefinitionPostProcessor:infrastructureComponent];
+    }
+    else if ([_definition.type conformsToProtocol:@protocol(TyphoonDefinitionPostProcessor)]) {
         [_componentFactory attachDefinitionPostProcessor:infrastructureComponent];
     }
     else if ([_definition.type conformsToProtocol:@protocol(TyphoonInstancePostProcessor)]) {

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -31,6 +31,8 @@
     TyphoonComponentFactory *_componentFactory;
 }
 
+// Сюда нужно передавать и assembly.
+// При процессинге definition'ов инфраструктурных компонентов, будем их неймспейсить.
 - (id)initWithDefinition:(TyphoonDefinition *)aDefinition componentFactory:(TyphoonComponentFactory *)aComponentFactory
 {
     self = [super init];

--- a/Source/Factory/TyphoonDefinitionRegisterer.m
+++ b/Source/Factory/TyphoonDefinitionRegisterer.m
@@ -31,8 +31,6 @@
     TyphoonComponentFactory *_componentFactory;
 }
 
-// Сюда нужно передавать и assembly.
-// При процессинге definition'ов инфраструктурных компонентов, будем их неймспейсить.
 - (id)initWithDefinition:(TyphoonDefinition *)aDefinition componentFactory:(TyphoonComponentFactory *)aComponentFactory
 {
     self = [super init];

--- a/Tests/Configuration/TyphoonConfigAppDelegateMock.h
+++ b/Tests/Configuration/TyphoonConfigAppDelegateMock.h
@@ -1,0 +1,18 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@interface TyphoonConfigAppDelegateMock : NSObject
+
+@property (strong, nonatomic) NSArray *fileNames;
+
+@end

--- a/Tests/Configuration/TyphoonConfigAppDelegateMock.m
+++ b/Tests/Configuration/TyphoonConfigAppDelegateMock.m
@@ -1,0 +1,20 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "TyphoonConfigAppDelegateMock.h"
+
+@implementation TyphoonConfigAppDelegateMock
+
+- (NSArray *)globalConfigFilenames {
+    return self.fileNames;
+}
+
+@end

--- a/Tests/Configuration/TyphoonGlobalConfigCollectorTests.m
+++ b/Tests/Configuration/TyphoonGlobalConfigCollectorTests.m
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <XCTest/XCTest.h>
+#import <OCMockitoIOS/OCMockitoIOS.h>
+
+#import "TyphoonGlobalConfigCollector.h"
+#import "TyphoonConfigAppDelegateMock.h"
+
+@interface TyphoonGlobalConfigCollectorTests : XCTestCase
+
+@end
+
+@implementation TyphoonGlobalConfigCollectorTests
+
+- (void)test_collector_fetches_plist
+{
+    TyphoonGlobalConfigCollector *collector = [[TyphoonGlobalConfigCollector alloc] initWithAppDelegate:nil];
+    NSBundle *testBundle = MKTMock([NSBundle class]);
+    
+    NSArray *expectedNames = @[@"config.plist"];
+    NSDictionary *testBundleInfo = @{
+                                     @"TyphoonGlobalConfigFilenames" : expectedNames
+                                     };
+    
+    [given([testBundle infoDictionary]) willReturn:testBundleInfo];
+    
+    NSArray *result = [collector obtainGlobalConfigFilenamesFromBundle:testBundle];
+    
+    [self verifyResult:result withExpectedNames:expectedNames];
+}
+
+- (void)test_collector_fetches_app_delegate
+{
+    TyphoonConfigAppDelegateMock *appDelegateMock = [TyphoonConfigAppDelegateMock new];
+    TyphoonGlobalConfigCollector *collector = [[TyphoonGlobalConfigCollector alloc] initWithAppDelegate:appDelegateMock];
+    
+    NSArray *expectedNames = @[@"config.plist"];
+    appDelegateMock.fileNames = expectedNames;
+    
+    NSArray *result = [collector obtainGlobalConfigFilenamesFromBundle:nil];
+    
+    [self verifyResult:result withExpectedNames:expectedNames];
+}
+
+- (void)test_collector_fetches_unique_bundle_id
+{
+    NSBundle *testBundle = [self generateTestBundleWithBundleIdBakedConfig];
+    TyphoonGlobalConfigCollector *collector = [[TyphoonGlobalConfigCollector alloc] initWithAppDelegate:nil];
+    
+    NSArray *expectedNames = @[@"config_test.plist"];
+    NSArray *result = [collector obtainGlobalConfigFilenamesFromBundle:testBundle];
+    
+    [self verifyResult:result withExpectedNames:expectedNames];
+}
+
+- (void)test_collector_fetches_old_style_plist
+{
+    TyphoonGlobalConfigCollector *collector = [[TyphoonGlobalConfigCollector alloc] initWithAppDelegate:nil];
+    NSBundle *testBundle = MKTMock([NSBundle class]);
+    
+    NSArray *expectedNames = @[@"config.plist"];
+    NSDictionary *testBundleInfo = @{
+                                     @"TyphoonConfigFilename" : @"config.plist"
+                                     };
+    
+    [given([testBundle infoDictionary]) willReturn:testBundleInfo];
+    
+    NSArray *result = [collector obtainGlobalConfigFilenamesFromBundle:testBundle];
+    
+    [self verifyResult:result withExpectedNames:expectedNames];
+}
+
+#pragma mark - Helper methods
+
+- (void)verifyResult:(NSArray *)result withExpectedNames:(NSArray *)expectedNames
+{
+    XCTAssertEqual(result.count, expectedNames.count);
+    
+    for (NSString *resultName in result) {
+        NSUInteger index = [result indexOfObject:resultName];
+        XCTAssertEqualObjects(resultName, expectedNames[index]);
+    }
+}
+
+- (NSBundle *)generateTestBundleWithBundleIdBakedConfig {
+    NSString *bundleId = @"test";
+    NSString *configFileName = @"config_test.plist";
+    NSBundle *testBundle = MKTMock([NSBundle class]);
+    NSDictionary *testBundleInfo = @{
+                                     @"CFBundleIdentifier" : bundleId
+                                     };
+    [given([testBundle infoDictionary]) willReturn:testBundleInfo];
+    
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    [given([testBundle resourcePath]) willReturn:documentsDirectory];
+    NSString *configPath = [documentsDirectory stringByAppendingPathComponent:configFileName];
+    NSData *testData = [configFileName dataUsingEncoding:NSUTF8StringEncoding];
+    
+    [[NSFileManager defaultManager] createFileAtPath:configPath
+                                            contents:testData
+                                          attributes:nil];
+    
+    return testBundle;
+}
+
+@end

--- a/Tests/Configuration/TyphoonTestAssemblyConfigPostProcessor.h
+++ b/Tests/Configuration/TyphoonTestAssemblyConfigPostProcessor.h
@@ -19,5 +19,7 @@
 @interface TyphoonTestAssemblyConfigPostProcessor : TyphoonAssembly
 
 - (Knight *)knight;
+- (Knight *)otherKnight;
+
 
 @end

--- a/Tests/Configuration/TyphoonTestAssemblyConfigPostProcessor.m
+++ b/Tests/Configuration/TyphoonTestAssemblyConfigPostProcessor.m
@@ -26,6 +26,13 @@
     }];
 }
 
+- (Knight *)otherKnight
+{
+    return [TyphoonDefinition withClass:[Knight class] configuration:^(TyphoonDefinition *definition) {
+        [definition injectProperty:@selector(damselsRescued) with:TyphoonConfig(@"damselsResqued")];
+    }];
+}
+
 - (id<Quest>)questWithUrl:(NSURL *)url
 {
     return [TyphoonDefinition withClass:[CampaignQuest class] configuration:^(TyphoonDefinition *definition) {

--- a/Tests/Factory/Assembly/TestAssemblies/Config/ConfigAssembly.m
+++ b/Tests/Factory/Assembly/TestAssemblies/Config/ConfigAssembly.m
@@ -20,7 +20,7 @@
 
 - (id)config
 {
-    return [TyphoonDefinition configDefinitionWithName:@"development_Config.plist"];
+    return [TyphoonDefinition withConfigName:@"development_Config.plist"];
 }
 
 - (Knight *)configuredCavalryMan

--- a/Tests/Factory/TyphoonNamespacingTests.m
+++ b/Tests/Factory/TyphoonNamespacingTests.m
@@ -1,0 +1,43 @@
+//
+//  TyphoonNamespacingTests.m
+//  Typhoon
+//
+//  Created by Egor Tolstoy on 15/11/15.
+//  Copyright © 2015 typhoonframework.org. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MiddleAgesAssembly.h"
+#import "CollaboratingMiddleAgesAssembly.h"
+#import "TyphoonBlockComponentFactory.h"
+#import "TyphoonComponentFactory+TyphoonDefinitionRegisterer.h"
+
+@interface TyphoonNamespacingTests : XCTestCase
+
+@end
+
+@implementation TyphoonNamespacingTests
+
+- (void)test_assembly_definition_namespacing
+{
+    MiddleAgesAssembly *assembly = [MiddleAgesAssembly new];
+    TyphoonBlockComponentFactory *factory = [TyphoonBlockComponentFactory factoryWithAssembly:assembly];
+    
+    TyphoonDefinition *definition = [factory definitionForKey:NSStringFromSelector(@selector(knight))];
+    XCTAssertEqualObjects(definition.space.key, NSStringFromClass([MiddleAgesAssembly class]));
+}
+
+- (void)test_collaborating_assemblies_definition_namespacing
+{
+    MiddleAgesAssembly *assembly = [MiddleAgesAssembly new];
+    CollaboratingMiddleAgesAssembly *collaboratingAssembly = [CollaboratingMiddleAgesAssembly assembly];
+    TyphoonBlockComponentFactory *factory = [TyphoonBlockComponentFactory factoryWithAssemblies:@[assembly, collaboratingAssembly]];
+    
+    TyphoonDefinition *definition1 = [factory definitionForKey:NSStringFromSelector(@selector(knight))];
+    XCTAssertEqualObjects(definition1.space.key, NSStringFromClass([MiddleAgesAssembly class]));
+    
+    TyphoonDefinition *definition2 = [factory definitionForKey:NSStringFromSelector(@selector(knightWithExternalQuest))];
+    XCTAssertEqualObjects(definition2.space.key, NSStringFromClass([CollaboratingMiddleAgesAssembly class]));
+}
+
+@end

--- a/Tests/Resources/PropertiesA.plist
+++ b/Tests/Resources/PropertiesA.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>damselsResqued</key>
+	<string>23</string>
+</dict>
+</plist>

--- a/Tests/Resources/PropertiesB.plist
+++ b/Tests/Resources/PropertiesB.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>damselsResqued</key>
+	<string>42</string>
+</dict>
+</plist>

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 		9F1187B01BEFEE3F008859E0 /* TyphoonGlobalConfigCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F1187A61BEFE452008859E0 /* TyphoonGlobalConfigCollector.h */; };
 		9F1187B21BEFF06D008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
 		9F1187B31BEFF06E008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
+		9F26AA6C1BF906D800663188 /* TyphoonNamespacingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C16E1BF904BF007030A5 /* TyphoonNamespacingTests.m */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -572,6 +573,7 @@
 		9FA1C16B1BF8E2D7007030A5 /* TyphoonDefinition+Namespacing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */; };
 		9FA1C16C1BF8E2DC007030A5 /* TyphoonDefinitionNamespace.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */; };
 		9FA1C16D1BF8E2DD007030A5 /* TyphoonDefinitionNamespace.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */; };
+		9FA1C16F1BF904BF007030A5 /* TyphoonNamespacingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C16E1BF904BF007030A5 /* TyphoonNamespacingTests.m */; };
 		9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; };
 		9FDF58D11BA4168100678B2B /* TyphoonStoryboardProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */; };
 		A5522B801AAA8C9500B93CD9 /* TyphoonPatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F601936F63A0083714E /* TyphoonPatcher.m */; };
@@ -1143,6 +1145,7 @@
 		9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonDefinitionNamespace.m; path = Namespacing/TyphoonDefinitionNamespace.m; sourceTree = "<group>"; };
 		9FA1C1671BF8E169007030A5 /* TyphoonDefinition+Namespacing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "TyphoonDefinition+Namespacing.h"; path = "Namespacing/TyphoonDefinition+Namespacing.h"; sourceTree = "<group>"; };
 		9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "TyphoonDefinition+Namespacing.m"; path = "Namespacing/TyphoonDefinition+Namespacing.m"; sourceTree = "<group>"; };
+		9FA1C16E1BF904BF007030A5 /* TyphoonNamespacingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonNamespacingTests.m; sourceTree = "<group>"; };
 		9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonStoryboardProvider.h; sourceTree = "<group>"; };
 		9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonStoryboardProvider.m; sourceTree = "<group>"; };
 		9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonStoryboardProviderTests.m; path = StoryboardProvider/TyphoonStoryboardProviderTests.m; sourceTree = "<group>"; };
@@ -1960,6 +1963,7 @@
 				6B076FEB1936F63A0083714E /* Internal */,
 				6B07700F1936F63A0083714E /* TyphoonComponentFactoryTests.m */,
 				6B0770101936F63A0083714E /* TyphoonScopeTests.m */,
+				9FA1C16E1BF904BF007030A5 /* TyphoonNamespacingTests.m */,
 				6B0770111936F63A0083714E /* WeakPool */,
 				2DBA19B51A836E74F55BEAB5 /* AutoInjection */,
 			);
@@ -3058,6 +3062,7 @@
 				6B0771011936FEA80083714E /* TyphoonPropertyInjectedAsCollectionTests.m in Sources */,
 				6B0771021936FEA80083714E /* FactoryReferenceInjectionsTests.m in Sources */,
 				6B0771031936FEA80083714E /* TyphoonRuntimeInjectionsTests.m in Sources */,
+				9FA1C16F1BF904BF007030A5 /* TyphoonNamespacingTests.m in Sources */,
 				6B0771071936FEA80083714E /* TyphoonDefinition+InstanceBuilderTests.m in Sources */,
 				9F98B2E81BA0BF5D00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */,
 				6B0771081936FEA80083714E /* TyphoonDefinition+Tests.m in Sources */,
@@ -3336,6 +3341,7 @@
 				6B0774461937839D0083714E /* NotSingletonA.m in Sources */,
 				6B0774471937839D0083714E /* SingletonA.m in Sources */,
 				6B0774481937839D0083714E /* SingletonB.m in Sources */,
+				9F26AA6C1BF906D800663188 /* TyphoonNamespacingTests.m in Sources */,
 				6B0774491937839D0083714E /* TyphoonPatcherTests.m in Sources */,
 				6B07744A1937839D0083714E /* TyphoonTestUtilsTests.m in Sources */,
 				6B07744B1937839D0083714E /* ClassWithPrimitiveTypesForConversion.m in Sources */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -550,6 +550,8 @@
 		9F1187B21BEFF06D008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
 		9F1187B31BEFF06E008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
 		9F26AA6C1BF906D800663188 /* TyphoonNamespacingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C16E1BF904BF007030A5 /* TyphoonNamespacingTests.m */; };
+		9F26AA6E1BF90E1000663188 /* PropertiesA.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9F26AA6D1BF90E1000663188 /* PropertiesA.plist */; };
+		9F26AA701BF9179F00663188 /* PropertiesB.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9F26AA6F1BF9179F00663188 /* PropertiesB.plist */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -1130,6 +1132,8 @@
 		9F1187A91BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonGlobalConfigCollectorTests.m; sourceTree = "<group>"; };
 		9F1187AB1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonConfigAppDelegateMock.h; sourceTree = "<group>"; };
 		9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonConfigAppDelegateMock.m; sourceTree = "<group>"; };
+		9F26AA6D1BF90E1000663188 /* PropertiesA.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PropertiesA.plist; sourceTree = "<group>"; };
+		9F26AA6F1BF9179F00663188 /* PropertiesB.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PropertiesB.plist; sourceTree = "<group>"; };
 		9F2C08A61BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonCollaboratingAssembliesCollector.h; sourceTree = "<group>"; };
 		9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollector.m; sourceTree = "<group>"; };
 		9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollectorTests.m; sourceTree = "<group>"; };
@@ -2202,6 +2206,8 @@
 				6B0770751936F63A0083714E /* SomeProperties.plist */,
 				6B0770761936F63A0083714E /* SomeProperties.properties */,
 				6B0770771936F63A0083714E /* SomeResource */,
+				9F26AA6D1BF90E1000663188 /* PropertiesA.plist */,
+				9F26AA6F1BF9179F00663188 /* PropertiesB.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2854,7 +2860,9 @@
 				6B0770911936F7FF0083714E /* Main_iPhone.storyboard in Resources */,
 				6B0770921936F8020083714E /* Main_iPad.storyboard in Resources */,
 				BA798A83DCF54BC475E5BAD6 /* development_Config.plist in Resources */,
+				9F26AA6E1BF90E1000663188 /* PropertiesA.plist in Resources */,
 				BA798230EE2BC01117C252D1 /* config_typhoonframework.org.Typhoon-iOS.plist in Resources */,
+				9F26AA701BF9179F00663188 /* PropertiesB.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -542,6 +542,12 @@
 		9F1187A21BEE2521008859E0 /* TyphoonPreattachedComponentsRegisterer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F11879F1BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.h */; };
 		9F1187A31BEE2536008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */; };
 		9F1187A41BEE253E008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */; };
+		9F1187A81BEFE452008859E0 /* TyphoonGlobalConfigCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */; };
+		9F1187AA1BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A91BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m */; };
+		9F1187AD1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
+		9F1187AE1BEFEE28008859E0 /* TyphoonGlobalConfigCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */; };
+		9F1187AF1BEFEE3B008859E0 /* TyphoonGlobalConfigCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */; };
+		9F1187B01BEFEE3F008859E0 /* TyphoonGlobalConfigCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F1187A61BEFE452008859E0 /* TyphoonGlobalConfigCollector.h */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -1110,6 +1116,11 @@
 		9F0F252F1BEA2571002AD880 /* TyphoonColorConversionUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonColorConversionUtils.m; path = Helpers/TyphoonColorConversionUtils.m; sourceTree = "<group>"; };
 		9F11879F1BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonPreattachedComponentsRegisterer.h; sourceTree = "<group>"; };
 		9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonPreattachedComponentsRegisterer.m; sourceTree = "<group>"; };
+		9F1187A61BEFE452008859E0 /* TyphoonGlobalConfigCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonGlobalConfigCollector.h; path = GlobalConfigResolver/TyphoonGlobalConfigCollector.h; sourceTree = "<group>"; };
+		9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonGlobalConfigCollector.m; path = GlobalConfigResolver/TyphoonGlobalConfigCollector.m; sourceTree = "<group>"; };
+		9F1187A91BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonGlobalConfigCollectorTests.m; sourceTree = "<group>"; };
+		9F1187AB1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonConfigAppDelegateMock.h; sourceTree = "<group>"; };
+		9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonConfigAppDelegateMock.m; sourceTree = "<group>"; };
 		9F2C08A61BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonCollaboratingAssembliesCollector.h; sourceTree = "<group>"; };
 		9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollector.m; sourceTree = "<group>"; };
 		9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonCollaboratingAssembliesCollectorTests.m; sourceTree = "<group>"; };
@@ -1381,6 +1392,7 @@
 		6B076E961936F63A0083714E /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				9F1187A51BEFE434008859E0 /* GlobalConfigResolver */,
 				6B076E971936F63A0083714E /* DefinitionOptionConfiguration */,
 				6B076EA21936F63A0083714E /* ConfigPostProcessor */,
 				6B076EAD1936F63A0083714E /* Resource */,
@@ -1848,6 +1860,9 @@
 				6B076FA01936F63A0083714E /* TyphoonInstancePostProcessorMock.h */,
 				6B076FA11936F63A0083714E /* TyphoonInstancePostProcessorMock.m */,
 				BA798E14534FB69AC182D402 /* TyphoonConfigPostProcessorTests.m */,
+				9F1187A91BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m */,
+				9F1187AB1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.h */,
+				9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */,
 				2DBA14D1F4E06EDCD57873A2 /* TyphoonTestAssemblyConfigPostProcessor.m */,
 				2DBA1FD54EF7A5EA7AF3E9FF /* TyphoonTestAssemblyConfigPostProcessor.h */,
 				BA798B18E939C961EC32A3F1 /* Startup */,
@@ -2391,6 +2406,15 @@
 			name = Helpers;
 			sourceTree = "<group>";
 		};
+		9F1187A51BEFE434008859E0 /* GlobalConfigResolver */ = {
+			isa = PBXGroup;
+			children = (
+				9F1187A61BEFE452008859E0 /* TyphoonGlobalConfigCollector.h */,
+				9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */,
+			);
+			name = GlobalConfigResolver;
+			sourceTree = "<group>";
+		};
 		9FDF58CF1BA4165700678B2B /* StoryboardProvider */ = {
 			isa = PBXGroup;
 			children = (
@@ -2567,6 +2591,7 @@
 				90ABC4B41A36B2A4008D8162 /* TyphoonSelector.h in Headers */,
 				90ABC4B51A36B2A4008D8162 /* TyphoonUtils.h in Headers */,
 				BA79856C39847DFDC799BA76 /* TyphoonCollaboratingAssemblyPropertyEnumerator.h in Headers */,
+				9F1187B01BEFEE3F008859E0 /* TyphoonGlobalConfigCollector.h in Headers */,
 				BA79830373597A7AA358C2D8 /* TyphoonCollaboratingAssemblyProxy.h in Headers */,
 				9F0591E11BE88408007CCB9C /* TyphoonStoryboardProvider.h in Headers */,
 				9F0591E01BE88404007CCB9C /* TyphoonViewHelpers.h in Headers */,
@@ -2908,6 +2933,7 @@
 				6B07709A1936F9000083714E /* TyphoonDefinition+Option.m in Sources */,
 				6B07709C1936F9000083714E /* TyphoonConfigPostProcessor.m in Sources */,
 				6B07709D1936F9000083714E /* TyphoonJsonStyleConfiguration.m in Sources */,
+				9F1187AD1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */,
 				6B07709E1936F9000083714E /* TyphoonPlistStyleConfiguration.m in Sources */,
 				6B07709F1936F9000083714E /* TyphoonPropertyStyleConfiguration.m in Sources */,
 				6B0770A01936F9000083714E /* TyphoonBundleResource.m in Sources */,
@@ -2918,6 +2944,7 @@
 				6B0770A51936F9000083714E /* TyphoonInjectionByComponentFactory.m in Sources */,
 				9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */,
 				9F1187A11BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */,
+				9F1187A81BEFE452008859E0 /* TyphoonGlobalConfigCollector.m in Sources */,
 				6B0770A61936F9000083714E /* TyphoonInjectionByConfig.m in Sources */,
 				6B0770A71936F9000083714E /* TyphoonInjectionByDictionary.m in Sources */,
 				6B0770A81936F9000083714E /* TyphoonInjectionByFactoryReference.m in Sources */,
@@ -3091,6 +3118,7 @@
 				2DBA1FB1F6532DA96182BD13 /* TyphoonTestAssemblyConfigPostProcessor.m in Sources */,
 				BA798F4DA9DF3F578134CB26 /* StoryboardFirstViewController.m in Sources */,
 				BA798443D914C3CC2B18B1BD /* StoryboardControllerDependency.m in Sources */,
+				9F1187AA1BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m in Sources */,
 				BA798DF76035BC090BFEA129 /* TyphoonAssemblyActivatorTests.m in Sources */,
 				BA79827D72CDD0B8CD0C7970 /* TyphoonAssemblyActivator.m in Sources */,
 				BA798492F3CF2FA4ADDF38E0 /* InvalidCollaboratingAssembly.m in Sources */,
@@ -3163,6 +3191,7 @@
 				6B0773C71937831B0083714E /* TyphoonStackElement.m in Sources */,
 				6B0773C81937831B0083714E /* TyphoonWeakComponentsPool.m in Sources */,
 				6B0773DA1937831B0083714E /* TyphoonComponentFactory.m in Sources */,
+				9F1187AE1BEFEE28008859E0 /* TyphoonGlobalConfigCollector.m in Sources */,
 				6B0773DB1937831B0083714E /* TyphoonDefinitionRegisterer.m in Sources */,
 				6B0773DC1937831B0083714E /* TyphoonPatcher.m in Sources */,
 				6B0773DE1937831B0083714E /* TyphoonTestUtils.m in Sources */,
@@ -3372,6 +3401,7 @@
 				90ABC4341A36B1B4008D8162 /* NSMethodSignature+TCFUnwrapValues.m in Sources */,
 				90ABC4351A36B1B4008D8162 /* NSValue+TCFUnwrapValues.m in Sources */,
 				90ABC4361A36B1B4008D8162 /* TyphoonCallStack.m in Sources */,
+				9F1187AF1BEFEE3B008859E0 /* TyphoonGlobalConfigCollector.m in Sources */,
 				90ABC4371A36B1B4008D8162 /* TyphoonComponentFactory+InstanceBuilder.m in Sources */,
 				90ABC4381A36B1B4008D8162 /* TyphoonFactoryPropertyInjectionPostProcessor.m in Sources */,
 				90ABC4391A36B1B4008D8162 /* TyphoonParentReferenceHydratingPostProcessor.m in Sources */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -566,6 +566,12 @@
 		9F65CEEB1BA1559E0015765B /* DecoratedQuest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F65CEE81BA1559A0015765B /* DecoratedQuest.m */; };
 		9F98B2E81BA0BF5D00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */; };
 		9F98B2EB1BA0BF5E00196820 /* TyphoonLoopedCollaboratingAssemblies.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */; };
+		9FA1C1661BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */; };
+		9FA1C1691BF8E169007030A5 /* TyphoonDefinition+Namespacing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */; };
+		9FA1C16A1BF8E2D6007030A5 /* TyphoonDefinition+Namespacing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */; };
+		9FA1C16B1BF8E2D7007030A5 /* TyphoonDefinition+Namespacing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */; };
+		9FA1C16C1BF8E2DC007030A5 /* TyphoonDefinitionNamespace.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */; };
+		9FA1C16D1BF8E2DD007030A5 /* TyphoonDefinitionNamespace.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */; };
 		9FDF58CE1BA4162100678B2B /* TyphoonStoryboardProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */; };
 		9FDF58D11BA4168100678B2B /* TyphoonStoryboardProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */; };
 		A5522B801AAA8C9500B93CD9 /* TyphoonPatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B076F601936F63A0083714E /* TyphoonPatcher.m */; };
@@ -1133,6 +1139,10 @@
 		9F7522371B80A25900AE6219 /* TyphoonAssemblyBuilder+PlistProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TyphoonAssemblyBuilder+PlistProcessor.m"; sourceTree = "<group>"; };
 		9F98B2DF1BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonLoopedCollaboratingAssemblies.h; sourceTree = "<group>"; };
 		9F98B2E01BA0BF3700196820 /* TyphoonLoopedCollaboratingAssemblies.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLoopedCollaboratingAssemblies.m; sourceTree = "<group>"; };
+		9FA1C1641BF8E0DC007030A5 /* TyphoonDefinitionNamespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TyphoonDefinitionNamespace.h; path = Namespacing/TyphoonDefinitionNamespace.h; sourceTree = "<group>"; };
+		9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonDefinitionNamespace.m; path = Namespacing/TyphoonDefinitionNamespace.m; sourceTree = "<group>"; };
+		9FA1C1671BF8E169007030A5 /* TyphoonDefinition+Namespacing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "TyphoonDefinition+Namespacing.h"; path = "Namespacing/TyphoonDefinition+Namespacing.h"; sourceTree = "<group>"; };
+		9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "TyphoonDefinition+Namespacing.m"; path = "Namespacing/TyphoonDefinition+Namespacing.m"; sourceTree = "<group>"; };
 		9FDF58CC1BA4162100678B2B /* TyphoonStoryboardProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonStoryboardProvider.h; sourceTree = "<group>"; };
 		9FDF58CD1BA4162100678B2B /* TyphoonStoryboardProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonStoryboardProvider.m; sourceTree = "<group>"; };
 		9FDF58D01BA4168100678B2B /* TyphoonStoryboardProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TyphoonStoryboardProviderTests.m; path = StoryboardProvider/TyphoonStoryboardProviderTests.m; sourceTree = "<group>"; };
@@ -1466,6 +1476,7 @@
 		6B076EB81936F63A0083714E /* Definition */ = {
 			isa = PBXGroup;
 			children = (
+				9FA1C1631BF8E0CA007030A5 /* Namespacing */,
 				6B076EB91936F63A0083714E /* Injections */,
 				6B076ED61936F63A0083714E /* Internal */,
 				6B076EE21936F63A0083714E /* Method */,
@@ -2416,6 +2427,17 @@
 			name = GlobalConfigResolver;
 			sourceTree = "<group>";
 		};
+		9FA1C1631BF8E0CA007030A5 /* Namespacing */ = {
+			isa = PBXGroup;
+			children = (
+				9FA1C1641BF8E0DC007030A5 /* TyphoonDefinitionNamespace.h */,
+				9FA1C1651BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m */,
+				9FA1C1671BF8E169007030A5 /* TyphoonDefinition+Namespacing.h */,
+				9FA1C1681BF8E169007030A5 /* TyphoonDefinition+Namespacing.m */,
+			);
+			name = Namespacing;
+			sourceTree = "<group>";
+		};
 		9FDF58CF1BA4165700678B2B /* StoryboardProvider */ = {
 			isa = PBXGroup;
 			children = (
@@ -2934,6 +2956,7 @@
 				6B07709A1936F9000083714E /* TyphoonDefinition+Option.m in Sources */,
 				6B07709C1936F9000083714E /* TyphoonConfigPostProcessor.m in Sources */,
 				6B07709D1936F9000083714E /* TyphoonJsonStyleConfiguration.m in Sources */,
+				9FA1C1661BF8E0DC007030A5 /* TyphoonDefinitionNamespace.m in Sources */,
 				6B07709E1936F9000083714E /* TyphoonPlistStyleConfiguration.m in Sources */,
 				6B07709F1936F9000083714E /* TyphoonPropertyStyleConfiguration.m in Sources */,
 				6B0770A01936F9000083714E /* TyphoonBundleResource.m in Sources */,
@@ -3002,6 +3025,7 @@
 				BA7983F8D0DDDE5371B74C24 /* TyphoonCollaboratingAssemblyPropertyEnumerator.m in Sources */,
 				BA7980CD12EE7634604F50AB /* TyphoonRuntimeArguments.m in Sources */,
 				BA79843184EDDDC88CA798AE /* TyphoonAssemblySelectorAdviser.m in Sources */,
+				9FA1C1691BF8E169007030A5 /* TyphoonDefinition+Namespacing.m in Sources */,
 				BA7988EFB2373212F66191F7 /* TyphoonCollaboratingAssemblyProxy.m in Sources */,
 				BA798DCFF0F7B36F55BC2850 /* TyphoonAssemblyDefinitionBuilder.m in Sources */,
 				BA7984490B57173B1CAB16D2 /* TyphoonBlockComponentFactory.m in Sources */,
@@ -3161,8 +3185,10 @@
 				6B0773A31937831B0083714E /* TyphoonInjectionByConfig.m in Sources */,
 				6B0773A41937831B0083714E /* TyphoonInjectionByDictionary.m in Sources */,
 				6B0773A51937831B0083714E /* TyphoonInjectionByFactoryReference.m in Sources */,
+				9FA1C16A1BF8E2D6007030A5 /* TyphoonDefinition+Namespacing.m in Sources */,
 				6B0773A61937831B0083714E /* TyphoonInjectionByObjectFromString.m in Sources */,
 				6B0773A71937831B0083714E /* TyphoonInjectionByObjectInstance.m in Sources */,
+				9FA1C16C1BF8E2DC007030A5 /* TyphoonDefinitionNamespace.m in Sources */,
 				6B0773A81937831B0083714E /* TyphoonInjectionByReference.m in Sources */,
 				6B0773A91937831B0083714E /* TyphoonInjectionByRuntimeArgument.m in Sources */,
 				6B0773AA1937831B0083714E /* TyphoonInjectionByType.m in Sources */,
@@ -3375,6 +3401,7 @@
 				90ABC4121A36B1B4008D8162 /* TyphoonInjectionByConfig.m in Sources */,
 				90ABC4131A36B1B4008D8162 /* TyphoonInjectionByDictionary.m in Sources */,
 				90ABC4141A36B1B4008D8162 /* TyphoonInjectionByFactoryReference.m in Sources */,
+				9FA1C16B1BF8E2D7007030A5 /* TyphoonDefinition+Namespacing.m in Sources */,
 				90ABC4151A36B1B4008D8162 /* TyphoonInjectionByObjectFromString.m in Sources */,
 				90ABC4161A36B1B4008D8162 /* TyphoonInjectionByObjectInstance.m in Sources */,
 				90ABC4171A36B1B4008D8162 /* TyphoonInjectionByReference.m in Sources */,
@@ -3434,6 +3461,7 @@
 				89FAD3211BA7C65900D3546B /* TyphoonStoryboardProvider.m in Sources */,
 				90ABC4521A36B1B4008D8162 /* TyphoonSelector.m in Sources */,
 				BA798291FCA4D6BB580C2786 /* TyphoonCollaboratingAssemblyPropertyEnumerator.m in Sources */,
+				9FA1C16D1BF8E2DD007030A5 /* TyphoonDefinitionNamespace.m in Sources */,
 				BA7984EC64F2861DE45E14FF /* TyphoonRuntimeArguments.m in Sources */,
 				BA798F16521A24A1D007E159 /* TyphoonAssemblySelectorAdviser.m in Sources */,
 				BA79841D0E7B27502BFB0C7C /* TyphoonCollaboratingAssemblyProxy.m in Sources */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -544,10 +544,11 @@
 		9F1187A41BEE253E008859E0 /* TyphoonPreattachedComponentsRegisterer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A01BEE22F2008859E0 /* TyphoonPreattachedComponentsRegisterer.m */; };
 		9F1187A81BEFE452008859E0 /* TyphoonGlobalConfigCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */; };
 		9F1187AA1BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A91BEFE841008859E0 /* TyphoonGlobalConfigCollectorTests.m */; };
-		9F1187AD1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
 		9F1187AE1BEFEE28008859E0 /* TyphoonGlobalConfigCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */; };
 		9F1187AF1BEFEE3B008859E0 /* TyphoonGlobalConfigCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187A71BEFE452008859E0 /* TyphoonGlobalConfigCollector.m */; };
 		9F1187B01BEFEE3F008859E0 /* TyphoonGlobalConfigCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F1187A61BEFE452008859E0 /* TyphoonGlobalConfigCollector.h */; };
+		9F1187B21BEFF06D008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
+		9F1187B31BEFF06E008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1187AC1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m */; };
 		9F2C08A81BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
 		9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E6FAB1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m */; };
 		9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C08A71BA0C7AF0049D751 /* TyphoonCollaboratingAssembliesCollector.m */; };
@@ -2933,7 +2934,6 @@
 				6B07709A1936F9000083714E /* TyphoonDefinition+Option.m in Sources */,
 				6B07709C1936F9000083714E /* TyphoonConfigPostProcessor.m in Sources */,
 				6B07709D1936F9000083714E /* TyphoonJsonStyleConfiguration.m in Sources */,
-				9F1187AD1BEFE891008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */,
 				6B07709E1936F9000083714E /* TyphoonPlistStyleConfiguration.m in Sources */,
 				6B07709F1936F9000083714E /* TyphoonPropertyStyleConfiguration.m in Sources */,
 				6B0770A01936F9000083714E /* TyphoonBundleResource.m in Sources */,
@@ -3052,6 +3052,7 @@
 				9F65CEDF1BA153DD0015765B /* TyphoonSingleAssembly.m in Sources */,
 				6B07711A1936FEA80083714E /* SimpleAssembly.m in Sources */,
 				6B07711B1936FEA80083714E /* SingletonsChainAssembly.m in Sources */,
+				9F1187B31BEFF06E008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */,
 				6B0771201936FEA80083714E /* ClassWithConstructor.m in Sources */,
 				9F0F25171BEA13CA002AD880 /* TyphoonTypeConversionUtilsTests.m in Sources */,
 				6B0771211936FEA80083714E /* PrimitiveMan.m in Sources */,
@@ -3304,6 +3305,7 @@
 				6B43ED5D1A8FA8870071EFC7 /* SwiftMiddleAgesAssembly.swift in Sources */,
 				6B0774431937839D0083714E /* Fort.m in Sources */,
 				6B0774441937839D0083714E /* Knight.m in Sources */,
+				9F1187B21BEFF06D008859E0 /* TyphoonConfigAppDelegateMock.m in Sources */,
 				6B0774451937839D0083714E /* MediocreQuest.m in Sources */,
 				6B0774461937839D0083714E /* NotSingletonA.m in Sources */,
 				6B0774471937839D0083714E /* SingletonA.m in Sources */,


### PR DESCRIPTION
This PR introduces namespacing for `TyphoonDefinitions` and `TyphoonConfigPostProcessors` (Issue #263).

There are two types of namespaces (`TyphoonDefinitionNamespace`):
- A global namespace,
- A namespace with the key equal to `TyphoonDefinition` assembly name.

Currently `TyphoonDefinition` namespaces only affects config injections, but it may be a useful feature for collaborating assemblies too.

TyphoonConfigs now work in the following way:
- Global configs (created via plist-integration, app-delegate integration, or using the deprecated methods) are used to inject values in definitions from any assembly,
- Per-assembly configs (created using new -`withConfigName:` family of methods) are used to inject values in definitions from the same assembly.

`TyphoonComponentFactory` holds its post processors in an ordered collection, so per-assembly configs will overwrite the global ones.

**Deprecations:**
```objc
+ (instancetype)configDefinitionWithName:(NSString *)fileName;
+ (instancetype)configDefinitionWithName:(NSString *)fileName bundle:(NSBundle *)fileBundle;
+ (instancetype)configDefinitionWithPath:(NSString *)filePath;
```