### PR TITLE
Prevent AutoInjection into readonly properties.

### DIFF
--- a/Source/Utils/TyphoonIntrospectionUtils.m
+++ b/Source/Utils/TyphoonIntrospectionUtils.m
@@ -36,7 +36,8 @@ Class TyphoonClassFromFrameworkString(NSString *className);
 
         static char buffer[256];
         const char *e = strchr(attributes, ',');
-        if (e == NULL) {
+        // R - stands for readonly properties. Typhoon should not try to inject readonly properties.
+        if ((e == NULL) || (strstr(attributes, ",R,"))) {
             return (NULL);
         }
 


### PR DESCRIPTION
Check for property attributes.
If it is a readonly property, Typhoon should leave it alone.
