### PR TITLE
Fixed problem with external TyphoonLoadedView outlets

### DIFF
--- a/Source/ios/Storyboard/TyphoonViewHelpers.m
+++ b/Source/ios/Storyboard/TyphoonViewHelpers.m
@@ -42,8 +42,10 @@
         BOOL replaceSecondItem = [constraint secondItem] == src;
         id firstItem = replaceFirstItem ? dst : constraint.firstItem;
         id secondItem = replaceSecondItem ? dst : constraint.secondItem;
-        NSLayoutConstraint *copy = [NSLayoutConstraint constraintWithItem:firstItem attribute:constraint.firstAttribute relatedBy:constraint.relation toItem:secondItem attribute:constraint.secondAttribute multiplier:constraint.multiplier constant:constraint.constant];
-        [dst addConstraint:copy];
+        // Use the same constraint instance that the external outlets
+        [constraint setValue:firstItem forKey:NSStringFromSelector(@selector(firstItem))];
+        [constraint setValue:secondItem forKey:NSStringFromSelector(@selector(secondItem))];
+        [dst addConstraint:constraint];
     }
     
     dst.frame = src.frame;

--- a/Tests/iOS/Storyboard/TyphoonViewHelpersTests.m
+++ b/Tests/iOS/Storyboard/TyphoonViewHelpersTests.m
@@ -154,7 +154,7 @@ BOOL equalProperties(NSLayoutConstraint *c1, NSLayoutConstraint *c2){
     XCTAssertEqual(dst.autoresizingMask, src.autoresizingMask);
     
     for (NSLayoutConstraint *dstConstraint in dst.constraints) {
-        BOOL didFindCopied = NO;
+        BOOL didFindEqualPointer = NO;
         
         for (NSLayoutConstraint *srcConstraint in src.constraints) {
             if (equalProperties(dstConstraint, srcConstraint)){
@@ -165,14 +165,15 @@ BOOL equalProperties(NSLayoutConstraint *c1, NSLayoutConstraint *c2){
                 id secondItem = replaceSecondItem ? dst : srcConstraint.secondItem;
                 
                 if ([dstConstraint.firstItem isEqual:firstItem] &&
-                    [dstConstraint.secondItem isEqual:secondItem]){
-                    didFindCopied = YES;
+                    [dstConstraint.secondItem isEqual:secondItem] &&
+                    dstConstraint == srcConstraint) {
+                    didFindEqualPointer = YES;
                     break;
                 }
             }
         }
         
-        XCTAssertTrue(didFindCopied, @"%@", dstConstraint.description);
+        XCTAssertTrue(didFindEqualPointer, @"%@", dstConstraint.description);
     }
     
     XCTAssertEqual(dst.constraints.count, src.constraints.count);


### PR DESCRIPTION
I create NSLayoutConstraint to TyphoonLoadedView and create IBOutlet for him. When controller with this view appeared, I changed the constant of the constraint.
This change did not work, because the outlet pointer does not coincide with any constraint of the TyphoonLoadedView.
I found out that the problem lies in the fact that a copy of NSLayoutConstraint.
I changed a copy on changing the value of the source and destination view and add this сonstraint (the same pointer) in view loaded from Nib.
This solved my problem. 