### PR TITLE
Introducing a less noisy way to describe definitions (TyphoonDefinitionProxy)

### DIFF
--- a/Source/Definition/Internal/TyphoonDefinitionProxy.h
+++ b/Source/Definition/Internal/TyphoonDefinitionProxy.h
@@ -15,7 +15,7 @@
 
 @interface TyphoonDefinitionProxy : NSProxy
 
-- (instancetype)initWithClass:(Class)clazz;
+- (instancetype)initWithClass:(Class)clazz configuration:(TyphoonDefinitionBlock)configuration;
 
 - (TyphoonDefinition *)__buildTyphoonDefinition;
 

--- a/Source/Definition/Internal/TyphoonDefinitionProxy.h
+++ b/Source/Definition/Internal/TyphoonDefinitionProxy.h
@@ -1,0 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#import <Foundation/Foundation.h>
+#import "TyphoonDefinition.h"
+
+@interface TyphoonDefinitionProxy : NSProxy
+
+- (instancetype)initWithClass:(Class)clazz;
+
+- (TyphoonDefinition *)__buildTyphoonDefinition;
+
+@end

--- a/Source/Definition/Internal/TyphoonDefinitionProxy.h
+++ b/Source/Definition/Internal/TyphoonDefinitionProxy.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2013, Typhoon Framework Contributors
+//  Copyright 2015, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/Definition/Internal/TyphoonDefinitionProxy.m
+++ b/Source/Definition/Internal/TyphoonDefinitionProxy.m
@@ -17,11 +17,14 @@
 {
     Class _definitionClass;
     NSMutableArray *_methodConfigurationBlocks;
+    TyphoonDefinitionBlock _extraConfigurationBlock;
 }
 
-- (instancetype)initWithClass:(Class)clazz
+- (instancetype)initWithClass:(Class)clazz configuration:(TyphoonDefinitionBlock)configuration
 {
     _definitionClass = clazz;
+    _extraConfigurationBlock = [configuration copy];
+    
     _methodConfigurationBlocks = [NSMutableArray array];
     
     return self;
@@ -70,6 +73,10 @@
     return [TyphoonDefinition withClass:_definitionClass configuration:^(TyphoonDefinition *definition) {
         for (TyphoonDefinitionBlock block in self->_methodConfigurationBlocks) {
             block(definition);
+        }
+        
+        if (self->_extraConfigurationBlock) {
+            self->_extraConfigurationBlock(definition);
         }
     }];
 }

--- a/Source/Definition/Internal/TyphoonDefinitionProxy.m
+++ b/Source/Definition/Internal/TyphoonDefinitionProxy.m
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#import "TyphoonDefinitionProxy.h"
+#import "TyphoonRuntimeArguments.h"
+
+@implementation TyphoonDefinitionProxy
+{
+    Class _definitionClass;
+    NSMutableArray *_methodConfigurationBlocks;
+}
+
+- (instancetype)initWithClass:(Class)clazz
+{
+    _definitionClass = clazz;
+    _methodConfigurationBlocks = [NSMutableArray array];
+    
+    return self;
+}
+
+- (BOOL)isKindOfClass:(Class)aClass
+{
+    return [TyphoonDefinitionProxy class] == aClass;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+    return [_definitionClass instanceMethodSignatureForSelector:sel];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    BOOL isInitializer = _methodConfigurationBlocks.count == 0;
+
+    if (isInitializer) {
+        __unsafe_unretained id unsafeSelf = self;
+        [anInvocation setReturnValue:&unsafeSelf];
+    }
+    
+    TyphoonRuntimeArguments *arguments = [TyphoonRuntimeArguments argumentsFromInvocation:anInvocation];
+    
+    void (^parametersBlock)(TyphoonMethod *) = ^(TyphoonMethod *method) {
+        [arguments enumerateArgumentsUsingBlock:^(id argument, NSUInteger index, BOOL *stop) {
+            [method injectParameterWith:argument];
+        }];
+    };
+    
+    TyphoonDefinitionBlock configurationBlock = ^(TyphoonDefinition *definition) {
+        if (isInitializer) {
+            [definition useInitializer:anInvocation.selector parameters:parametersBlock];
+        } else {
+            [definition injectMethod:anInvocation.selector parameters:parametersBlock];
+        }
+    };
+    
+    [_methodConfigurationBlocks addObject:[configurationBlock copy]];
+}
+
+- (TyphoonDefinition *)__buildTyphoonDefinition
+{
+    return [TyphoonDefinition withClass:_definitionClass configuration:^(TyphoonDefinition *definition) {
+        for (TyphoonDefinitionBlock block in self->_methodConfigurationBlocks) {
+            block(definition);
+        }
+    }];
+}
+
+@end

--- a/Source/Definition/Internal/TyphoonDefinitionProxy.m
+++ b/Source/Definition/Internal/TyphoonDefinitionProxy.m
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2013, Typhoon Framework Contributors
+//  Copyright 2015, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/Definition/Proxy/NSObject+TyphoonDefinition.h
+++ b/Source/Definition/Proxy/NSObject+TyphoonDefinition.h
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#import <Foundation/Foundation.h>
+
+@interface NSObject (TyphoonDefinition)
+
++ (instancetype)typhoonDefinition;
+
+@end

--- a/Source/Definition/Proxy/NSObject+TyphoonDefinition.h
+++ b/Source/Definition/Proxy/NSObject+TyphoonDefinition.h
@@ -11,9 +11,12 @@
 
 
 #import <Foundation/Foundation.h>
+#import "TyphoonDefinition.h"
 
 @interface NSObject (TyphoonDefinition)
 
 + (instancetype)typhoonDefinition;
+
++ (instancetype)typhoonDefinitionWithScope:(TyphoonScope)scope;
 
 @end

--- a/Source/Definition/Proxy/NSObject+TyphoonDefinition.h
+++ b/Source/Definition/Proxy/NSObject+TyphoonDefinition.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2013, Typhoon Framework Contributors
+//  Copyright 2015, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/Definition/Proxy/NSObject+TyphoonDefinition.m
+++ b/Source/Definition/Proxy/NSObject+TyphoonDefinition.m
@@ -17,7 +17,14 @@
 
 + (instancetype)typhoonDefinition
 {
-    return (id)[[TyphoonDefinitionProxy alloc] initWithClass:[self class]];
+    return (id)[[TyphoonDefinitionProxy alloc] initWithClass:[self class] configuration:nil];
+}
+
++ (instancetype)typhoonDefinitionWithScope:(TyphoonScope)scope
+{
+    return (id)[[TyphoonDefinitionProxy alloc] initWithClass:[self class] configuration:^(TyphoonDefinition *definition) {
+        definition.scope = scope;
+    }];
 }
 
 @end

--- a/Source/Definition/Proxy/NSObject+TyphoonDefinition.m
+++ b/Source/Definition/Proxy/NSObject+TyphoonDefinition.m
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2013, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#import "NSObject+TyphoonDefinition.h"
+#import "TyphoonDefinitionProxy.h"
+
+@implementation NSObject (TyphoonDefinition)
+
++ (instancetype)typhoonDefinition
+{
+    return (id)[[TyphoonDefinitionProxy alloc] initWithClass:[self class]];
+}
+
+@end

--- a/Source/Definition/Proxy/NSObject+TyphoonDefinition.m
+++ b/Source/Definition/Proxy/NSObject+TyphoonDefinition.m
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2013, Typhoon Framework Contributors
+//  Copyright 2015, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/Factory/Internal/TyphoonAssemblyDefinitionBuilder.m
+++ b/Source/Factory/Internal/TyphoonAssemblyDefinitionBuilder.m
@@ -24,6 +24,7 @@
 #import "TyphoonRuntimeArguments.h"
 #import "TyphoonReferenceDefinition.h"
 #import "TyphoonDefinition+Namespacing.h"
+#import "TyphoonDefinitionProxy.h"
 
 #import <objc/runtime.h>
 
@@ -174,6 +175,11 @@ static void AssertArgumentType(id target, SEL selector, const char *argumentType
         objc_msgSend_InjectionArguments(self.assembly, sel, signature); // the advisedSEL will call through to the original, unwrapped implementation because prepareForUse has been called, and all our definition methods have been swizzled.
     // This method will likely call through to other definition methods on the assembly, which will go through the advising machinery because of this swizzling.
     // Therefore, the definitions a definition depends on will be fully constructed before they are needed to construct that definition.
+    
+    if ([cached isKindOfClass:[TyphoonDefinitionProxy class]]) {
+        cached = [((TyphoonDefinitionProxy *)cached) __buildTyphoonDefinition];
+    }
+    
     return cached;
 }
 

--- a/Source/Typhoon.h
+++ b/Source/Typhoon.h
@@ -24,6 +24,7 @@ FOUNDATION_EXPORT const unsigned char TyphoonVersionString[];
 #import "TyphoonDefinition.h"
 #import "TyphoonFactoryDefinition.h"
 #import "TyphoonDefinition+Infrastructure.h"
+#import "NSObject+TyphoonDefinition.h"
 #import "TyphoonMethod.h"
 #import "TyphoonConfigPostProcessor.h"
 #import "TyphoonResource.h"

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.h
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.h
@@ -104,4 +104,8 @@
 
 - (id)occasionallyNilKnightWithMethodInjections;
 
+- (id)knightWithDefinitionProxy;
+
+- (id)knightWithDefinitionProxyAndRuntimeDamselsRescued:(NSNumber *)damselsRescued runtimeFoobar:(NSObject *)runtimeObject;
+
 @end

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
@@ -416,4 +416,21 @@
     }];
 }
 
+- (id)knightWithDefinitionProxy
+{
+    Knight *knight = [[Knight typhoonDefinitionWithScope:TyphoonScopeSingleton] init];
+    [knight setQuest:[self defaultQuest] andDamselsRescued:(NSUInteger)@(12)];
+//    knight.hasHorseWillTravel = (BOOL)@(YES);
+    knight.foobar = @(42);
+    return knight;
+}
+
+- (id)knightWithDefinitionProxyAndRuntimeDamselsRescued:(NSNumber *)damselsRescued runtimeFoobar:(NSObject *)runtimeObject
+{
+    Knight *knight = [[Knight typhoonDefinition] initWithDamselsRescued:(NSUInteger)damselsRescued foo:runtimeObject];
+//    knight.hasHorseWillTravel = (BOOL)@(YES);
+    [knight setFavoriteQuest:[self defaultQuest]];
+    return knight;
+}
+
 @end

--- a/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
+++ b/Tests/Factory/Internal/TyphoonBlockComponentFactoryTests.m
@@ -384,5 +384,35 @@ test_currently_resolving_references_dictionary_is_not_overwritten_when_initializ
     XCTAssertEqual(knight.damselsRescued, (NSUInteger)3);
 }
 
+//-------------------------------------------------------------------------------------------
+#pragma mark - Definition proxy
+
+- (void)test_returns_instance_configured_with_definition_proxy
+{
+    MiddleAgesAssembly *assembly = (MiddleAgesAssembly *)_componentFactory;
+    
+    Knight *knight = [assembly knightWithDefinitionProxy];
+    XCTAssertNotNil(knight);
+    XCTAssertNotNil(knight.quest);
+    XCTAssertEqual(knight.damselsRescued, (NSUInteger)12);
+//    XCTAssertEqual(knight.hasHorseWillTravel, YES);
+    XCTAssertEqual(knight.foobar, @(42));
+    
+    Knight *anotherKnight = [assembly knightWithDefinitionProxy];
+    XCTAssertTrue(knight == anotherKnight);
+}
+
+- (void)test_returns_instance_configured_with_definition_proxy_using_custom_initializer_and_runtime_arguments
+{
+    MiddleAgesAssembly *assembly = (MiddleAgesAssembly *)_componentFactory;
+    
+    Knight *knight = [assembly knightWithDefinitionProxyAndRuntimeDamselsRescued:@(12) runtimeFoobar:@(42)];
+    XCTAssertNotNil(knight);
+    XCTAssertNotNil(knight.favoriteQuest);
+    XCTAssertEqual(knight.damselsRescued, (NSUInteger)12);
+//    XCTAssertEqual(knight.hasHorseWillTravel, YES);
+    XCTAssertEqual(knight.foobar, @(42));
+}
+
 @end
 

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01B32D951C2214EB0089D743 /* NSObject+TyphoonDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B32D941C2214EB0089D743 /* NSObject+TyphoonDefinition.m */; };
+		01B32D981C2233830089D743 /* TyphoonDefinitionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B32D961C2233830089D743 /* TyphoonDefinitionProxy.m */; };
+		01B32D9A1C2243FF0089D743 /* TyphoonDefinitionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B32D961C2233830089D743 /* TyphoonDefinitionProxy.m */; };
+		01B32D9B1C2243FF0089D743 /* TyphoonDefinitionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B32D961C2233830089D743 /* TyphoonDefinitionProxy.m */; };
+		01B32D9C1C22440B0089D743 /* NSObject+TyphoonDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B32D941C2214EB0089D743 /* NSObject+TyphoonDefinition.m */; };
+		01B32D9D1C22440B0089D743 /* NSObject+TyphoonDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B32D941C2214EB0089D743 /* NSObject+TyphoonDefinition.m */; };
 		2DBA12F920B6F629203ABFB3 /* AutoInjectionKnight.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA18F5476952207F6E2B0D /* AutoInjectionKnight.m */; };
 		2DBA13020BD1DDD15231B84C /* TyphoonInjections.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1FC6F594C49C7D8261A6 /* TyphoonInjections.m */; };
 		2DBA133CA352D9C555482734 /* TyphoonInjectionDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1851EF633B38D4C7866A /* TyphoonInjectionDefinition.m */; };
@@ -763,6 +769,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01B32D941C2214EB0089D743 /* NSObject+TyphoonDefinition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+TyphoonDefinition.m"; sourceTree = "<group>"; };
+		01B32D961C2233830089D743 /* TyphoonDefinitionProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonDefinitionProxy.m; sourceTree = "<group>"; };
+		01B32D971C2233830089D743 /* TyphoonDefinitionProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonDefinitionProxy.h; sourceTree = "<group>"; };
+		01B32D991C2236810089D743 /* NSObject+TyphoonDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+TyphoonDefinition.h"; sourceTree = "<group>"; };
 		269BC6BA1BAFEC19005A1DA3 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		2DBA102EFAD54C22C82B4834 /* TyphoonOptionMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonOptionMatcher.m; sourceTree = "<group>"; };
 		2DBA10314E7114955C0AB31E /* TyphoonNemoTestAssemblies.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonNemoTestAssemblies.m; sourceTree = "<group>"; };
@@ -1315,6 +1325,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01B32D8F1C22149B0089D743 /* Proxy */ = {
+			isa = PBXGroup;
+			children = (
+				01B32D991C2236810089D743 /* NSObject+TyphoonDefinition.h */,
+				01B32D941C2214EB0089D743 /* NSObject+TyphoonDefinition.m */,
+			);
+			path = Proxy;
+			sourceTree = "<group>";
+		};
 		2DBA12DFCF0F49DFCC18384B /* Startup */ = {
 			isa = PBXGroup;
 			children = (
@@ -1495,9 +1514,10 @@
 				6B076EB91936F63A0083714E /* Injections */,
 				6B076ED61936F63A0083714E /* Internal */,
 				6B076EE21936F63A0083714E /* Method */,
+				2DBA1C277BF70F0F6B4E7374 /* AutoInjection */,
+				01B32D8F1C22149B0089D743 /* Proxy */,
 				6B076EE81936F63A0083714E /* TyphoonDefinition.h */,
 				6B076EE91936F63A0083714E /* TyphoonDefinition.m */,
-				2DBA1C277BF70F0F6B4E7374 /* AutoInjection */,
 			);
 			path = Definition;
 			sourceTree = "<group>";
@@ -1554,10 +1574,12 @@
 				6B076EDF1936F63A0083714E /* TyphoonObjectWithCustomInjection.h */,
 				6B076EE01936F63A0083714E /* TyphoonReferenceDefinition.h */,
 				6B076EE11936F63A0083714E /* TyphoonReferenceDefinition.m */,
-				2DBA13E1E8F0928568F42BE0 /* TyphoonFactoryDefinition.m */,
 				2DBA1FB2212B952164C02878 /* TyphoonFactoryDefinition.h */,
-				2DBA1851EF633B38D4C7866A /* TyphoonInjectionDefinition.m */,
+				2DBA13E1E8F0928568F42BE0 /* TyphoonFactoryDefinition.m */,
 				2DBA1463AEC1B97752A6DF8C /* TyphoonInjectionDefinition.h */,
+				2DBA1851EF633B38D4C7866A /* TyphoonInjectionDefinition.m */,
+				01B32D971C2233830089D743 /* TyphoonDefinitionProxy.h */,
+				01B32D961C2233830089D743 /* TyphoonDefinitionProxy.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -3010,6 +3032,7 @@
 				6B0770B11936F9000083714E /* TyphoonDefinition+Infrastructure.m in Sources */,
 				6B0770B21936F9000083714E /* TyphoonDefinition+InstanceBuilder.m in Sources */,
 				6B0770B31936F9000083714E /* TyphoonReferenceDefinition.m in Sources */,
+				01B32D981C2233830089D743 /* TyphoonDefinitionProxy.m in Sources */,
 				6B0770B41936F9000083714E /* TyphoonMethod+InstanceBuilder.m in Sources */,
 				6B0770B51936F9000083714E /* TyphoonMethod.m in Sources */,
 				6B0770B61936F9000083714E /* TyphoonDefinition.m in Sources */,
@@ -3028,6 +3051,7 @@
 				6B0770CA1936F9000083714E /* TyphoonStackElement.m in Sources */,
 				6B0770CB1936F9000083714E /* TyphoonWeakComponentsPool.m in Sources */,
 				6B0770DD1936F9000083714E /* TyphoonComponentFactory.m in Sources */,
+				01B32D951C2214EB0089D743 /* NSObject+TyphoonDefinition.m in Sources */,
 				6B0770DE1936F9000083714E /* TyphoonDefinitionRegisterer.m in Sources */,
 				6B0770DF1936F9000083714E /* TyphoonViewControllerNibResolver.m in Sources */,
 				6B0770E01936F9000083714E /* TyphoonStoryboard.m in Sources */,
@@ -3242,6 +3266,8 @@
 				6B0773C31937831B0083714E /* TyphoonCallStack.m in Sources */,
 				6B0773C41937831B0083714E /* TyphoonComponentFactory+InstanceBuilder.m in Sources */,
 				6B0773C51937831B0083714E /* TyphoonFactoryPropertyInjectionPostProcessor.m in Sources */,
+				01B32D9C1C22440B0089D743 /* NSObject+TyphoonDefinition.m in Sources */,
+				01B32D9A1C2243FF0089D743 /* TyphoonDefinitionProxy.m in Sources */,
 				9F65CEDA1BA153850015765B /* TyphoonCollaboratingAssembliesCollector.m in Sources */,
 				6B0773C61937831B0083714E /* TyphoonParentReferenceHydratingPostProcessor.m in Sources */,
 				6B0773C71937831B0083714E /* TyphoonStackElement.m in Sources */,
@@ -3465,6 +3491,7 @@
 				90ABC4381A36B1B4008D8162 /* TyphoonFactoryPropertyInjectionPostProcessor.m in Sources */,
 				90ABC4391A36B1B4008D8162 /* TyphoonParentReferenceHydratingPostProcessor.m in Sources */,
 				90ABC43A1A36B1B4008D8162 /* TyphoonStackElement.m in Sources */,
+				01B32D9D1C22440B0089D743 /* NSObject+TyphoonDefinition.m in Sources */,
 				90ABC43B1A36B1B4008D8162 /* TyphoonWeakComponentsPool.m in Sources */,
 				9F65CEE31BA1555B0015765B /* TyphoonAssemblyBuilder.m in Sources */,
 				90ABC43C1A36B1B4008D8162 /* TyphoonComponentFactory.m in Sources */,
@@ -3488,6 +3515,7 @@
 				90ABC44F1A36B1B4008D8162 /* NSObject+TyphoonIntrospectionUtils.m in Sources */,
 				90ABC4501A36B1B4008D8162 /* TyphoonSwizzlerDefaultImpl.m in Sources */,
 				90ABC4511A36B1B4008D8162 /* TyphoonIntrospectionUtils.m in Sources */,
+				01B32D9B1C2243FF0089D743 /* TyphoonDefinitionProxy.m in Sources */,
 				89FAD3211BA7C65900D3546B /* TyphoonStoryboardProvider.m in Sources */,
 				90ABC4521A36B1B4008D8162 /* TyphoonSelector.m in Sources */,
 				BA798291FCA4D6BB580C2786 /* TyphoonCollaboratingAssemblyPropertyEnumerator.m in Sources */,


### PR DESCRIPTION
Hey guys!

We have a pretty big project that uses Typhoon extensively - that is, we have about 20 assemblies each containing dozens of definitions. This is a sizeable amount of code which, quite frankly, doesn't always look friendly. Consider this example taken from the real project:

```
- (PXSession *)session {
    return [TyphoonDefinition withClass:[PXSession class] configuration:^(TyphoonDefinition *definition) {
        [definition useInitializer:@selector(initWithCore:requestSender:imageCacheFactory:URLSessionManager:reachability:tutorialScenarioManager:) parameters:^(TyphoonMethod *initializer) {
            [initializer injectParameterWith:[self core]];
            [initializer injectParameterWith:[self requestSender]];
            [initializer injectParameterWith:self];
            [initializer injectParameterWith:[self URLSessionManager]];
            [initializer injectParameterWith:[self reachability]];
            [initializer injectParameterWith:[self.tutorialAssembly scenarioManager]];
        }];

        [definition injectProperty:@selector(analyticsManager) with:[self.analyticsAssembly analyticsManager]];
    }];    
}
```
Definitely not the worst piece of code, but it's far from being readable because arguments are separated from the initializer. It also makes it harder for changing and refactoring, and so on.

So I figured out it can be done in a cleaner way :) Consider this:

```
- (PXSession *)session {
    PXSession *session = [[PXSession typhoonDefinition] initWithCore:[self core]
                                                       requestSender:[self requestSender]
                                                   imageCacheFactory:self
                                                   URLSessionManager:[self URLSessionManager]
                                                        reachability:[self reachability]
                                             tutorialScenarioManager:[self.tutorialAssembly scenarioManager]];

    session.analyticsManager = [self.analyticsAssembly analyticsManager];

    return session;
}
```

This looks exactly like your normal code. Also, a compiler gets to do it job properly in checking for methods and properties.

I've made an implementation for this, introducing `TyphoonDefinitionProxy` class. It's pretty straightforward: it collects invocations and converts them to definition configuration blocks, which are later used to build a proper definition. I had to add a check for this new class in the place where `TyphoonAssemblyDefinitionBuilder` fetches a definition - not the best thing to do, but unfortunately I can't see a better way to do so because there is no protocol for this and I don't feel authorized to add it :) I also added a couple of tests, not sure if I chose a correct place for them though.

This same machinery can be used for factory definitions too - not done yet, but if you like the whole thing, I don't see why not.

The only caveat for this comes from the limitation Typhoon currently has - that is, lacking support for scalars. You can see in the tests that I have to casts objects to scalar integers, and this is uncool. To make things worse, it doesn't work for scalar properties at all, because of the magic of automatic unboxing. I don't see why there is a such limitation in the first place - `TyphoonRuntimeArguments` can be improved to support scalar arguments, and I'm willing to do so in a separate PR. :)

Please tell me if any part of this needs some extra work, I'd be glad to polish it :)