### PR TITLE
Converting NSStackBlock to NSMallocBlock

### DIFF
--- a/Source/Factory/Internal/NSInvocation+TCFWrapValues.m
+++ b/Source/Factory/Internal/NSInvocation+TCFWrapValues.m
@@ -12,6 +12,7 @@
 
 #import "NSInvocation+TCFWrapValues.h"
 #import "TyphoonUtils.h"
+#import "TyphoonIntrospectionUtils.h"
 
 @implementation NSInvocation (TCFWrapValues)
 
@@ -26,6 +27,11 @@
         void *pointer;
         [self getArgument:&pointer atIndex:idx];
         id argument = (__bridge id) pointer;
+        
+        if (IsBlock(argumentType)) {
+            return [argument copy]; // Converting NSStackBlock to NSMallocBlock
+        }
+        
         return argument;
     } else {
         NSUInteger argumentSize;

--- a/Source/Utils/TyphoonIntrospectionUtils.h
+++ b/Source/Utils/TyphoonIntrospectionUtils.h
@@ -22,7 +22,7 @@ NSString *TyphoonTypeStringFor(id classOrProtocol);
 Class TyphoonClassFromString(NSString *className);
 
 BOOL IsClass(id classOrProtocol);
-
+BOOL IsBlock(const char *objCType);
 BOOL IsProtocol(id classOrProtocol);
 
 @interface TyphoonIntrospectionUtils : NSObject

--- a/Source/Utils/TyphoonIntrospectionUtils.m
+++ b/Source/Utils/TyphoonIntrospectionUtils.m
@@ -378,6 +378,11 @@ BOOL IsClass(id classOrProtocol)
     return class_isMetaClass(object_getClass(classOrProtocol));
 }
 
+BOOL IsBlock(const char *objCType)
+{
+    return strcmp(objCType, "@?") == 0;
+}
+
 BOOL IsProtocol(id classOrProtocol)
 {
     return object_getClass(classOrProtocol) == object_getClass(@protocol(NSObject));

--- a/Tests/Utils/TyphoonInvocationUtilsTestObjects.h
+++ b/Tests/Utils/TyphoonInvocationUtilsTestObjects.h
@@ -12,6 +12,13 @@
 
 #import <Foundation/Foundation.h>
 
+@interface ObjectInitWithBlock : NSObject
+
++ (void)setBlock:(void(^)())block;
+
+@end
+
+
 @interface ObjectInitRetained : NSObject
 
 @end

--- a/Tests/Utils/TyphoonInvocationUtilsTestObjects.h
+++ b/Tests/Utils/TyphoonInvocationUtilsTestObjects.h
@@ -12,7 +12,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface ObjectInitWithBlock : NSObject
+@interface ObjectBlockArgument : NSObject
 
 + (void)setBlock:(void(^)())block;
 

--- a/Tests/Utils/TyphoonInvocationUtilsTestObjects.m
+++ b/Tests/Utils/TyphoonInvocationUtilsTestObjects.m
@@ -12,6 +12,15 @@
 
 #import "TyphoonInvocationUtilsTestObjects.h"
 
+@implementation ObjectInitWithBlock
+
++ (void)setBlock:(void (^)())block
+{
+    block();
+}
+
+@end
+
 @implementation ObjectInitRetained
 
 - (instancetype)init

--- a/Tests/Utils/TyphoonInvocationUtilsTestObjects.m
+++ b/Tests/Utils/TyphoonInvocationUtilsTestObjects.m
@@ -12,7 +12,7 @@
 
 #import "TyphoonInvocationUtilsTestObjects.h"
 
-@implementation ObjectInitWithBlock
+@implementation ObjectBlockArgument
 
 + (void)setBlock:(void (^)())block
 {
@@ -78,6 +78,8 @@
 
     return nil;
 }
+
+
 
 @end
 

--- a/Tests/Utils/TyphoonInvocationUtilsTests.m
+++ b/Tests/Utils/TyphoonInvocationUtilsTests.m
@@ -13,6 +13,7 @@
 #import <XCTest/XCTest.h>
 #import "TyphoonInvocationUtilsTestObjects.h"
 #import "NSInvocation+TCFInstanceBuilder.h"
+#import "NSInvocation+TCFWrapValues.h"
 #import <objc/message.h>
 #import "ClassWithConstructor.h"
 
@@ -66,6 +67,26 @@
     [invocation getReturnValue:&arcobject];
 
     XCTAssertEqual(retainCount(arcobject), 1);
+}
+
+- (void)test_block_argument_is_malloc
+{
+    NSObject *retainedObject = [NSObject new];
+    
+    NSInvocation *invocation = [TyphoonInvocationUtilsTests invocationForClassSelector:@selector(setBlock:) class:[ObjectInitWithBlock class]];
+    void (^Block)() = ^{
+        if (retainedObject) {
+            ///
+        }
+    };
+    [invocation setArgument:&Block atIndex:2];
+    [invocation invoke];
+    
+    id value = [invocation typhoon_getArgumentObjectAtIndex:2];
+    
+    XCTAssertTrue([value isKindOfClass:NSClassFromString(@"__NSMallocBlock__")]);
+    XCTAssertEqual(retainCount(value), 1);
+    XCTAssertEqual(retainCount(retainedObject), 3);
 }
 
 - (void)test_object_new_autorelease

--- a/Tests/Utils/TyphoonInvocationUtilsTests.m
+++ b/Tests/Utils/TyphoonInvocationUtilsTests.m
@@ -73,7 +73,7 @@
 {
     NSObject *retainedObject = [NSObject new];
     
-    NSInvocation *invocation = [TyphoonInvocationUtilsTests invocationForClassSelector:@selector(setBlock:) class:[ObjectInitWithBlock class]];
+    NSInvocation *invocation = [TyphoonInvocationUtilsTests invocationForClassSelector:@selector(setBlock:) class:[ObjectBlockArgument class]];
     void (^Block)() = ^{
         if (retainedObject) {
             ///


### PR DESCRIPTION
This MR linked to [issue](https://github.com/appsquickly/Typhoon/issues/493)

Conclusions: 
Function ```[self getArgument:&pointer atIndex:idx];``` into ```- (id)typhoon_getArgumentObjectAtIndex:(NSInteger)idx``` returns NSStackBlock. Stack block cannot simply be retained. If we want retain block, we need to convert NSStackBlock to NSMallocBlock.

In addition, I can write tests for this case if needed :)