### PR TITLE
#456(issue)-Implemented wrapping primitive values for NSInvocation category resultOfInvokingOn:

### DIFF
--- a/Source/Factory/Internal/NSInvocation+TCFInstanceBuilder.m
+++ b/Source/Factory/Internal/NSInvocation+TCFInstanceBuilder.m
@@ -10,6 +10,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #import "NSInvocation+TCFInstanceBuilder.h"
+#import "NSInvocation+TCFWrapValues.h"
 
 #if __has_feature(objc_arc)
 #error You have to disable ARC for this file
@@ -50,11 +51,10 @@ static BOOL typhoon_IsSelectorReturnsRetained(SEL selector) {
 
 - (id)typhoon_resultOfInvokingOn:(id)instanceOrClass NS_RETURNS_RETAINED
 {
-    id returnValue = nil;
+    [self invokeWithTarget:instanceOrClass];
+    id returnValue = [self typhoon_getReturnValue];
 
     BOOL isReturnsRetained = typhoon_IsSelectorReturnsRetained([self selector]);
-    [self invokeWithTarget:instanceOrClass];
-    [self getReturnValue:&returnValue];
     if (!isReturnsRetained) {
         [returnValue retain]; /* Retain to take ownership on autoreleased object */
     }

--- a/Source/Factory/Internal/NSInvocation+TCFWrapValues.h
+++ b/Source/Factory/Internal/NSInvocation+TCFWrapValues.h
@@ -17,7 +17,7 @@
 /** Get argument at index, wrapping primitive values in NSValue if needed */
 - (id)typhoon_getArgumentObjectAtIndex:(NSInteger)idx;
 
-/** Get return value, wrapping primitive values in NSValue if needed*/
+/** Get return value, wrapping primitive values in NSValue if needed */
 - (id)typhoon_getReturnValue;
 
 @end

--- a/Source/Factory/Internal/NSInvocation+TCFWrapValues.h
+++ b/Source/Factory/Internal/NSInvocation+TCFWrapValues.h
@@ -17,4 +17,7 @@
 /** Get argument at index, wrapping primitive values in NSValue if needed */
 - (id)typhoon_getArgumentObjectAtIndex:(NSInteger)idx;
 
+/** Get return value, wrapping primitive values in NSValue if needed*/
+- (id)typhoon_getReturnValue;
+
 @end

--- a/Source/Factory/Internal/NSInvocation+TCFWrapValues.m
+++ b/Source/Factory/Internal/NSInvocation+TCFWrapValues.m
@@ -37,8 +37,8 @@
     }
 
     if (CStringEquals(type, "@") || // object
-            CStringEquals(type, "@?") || // block
-            CStringEquals(type, "#")) // metaclass
+        CStringEquals(type, "@?") || // block
+        CStringEquals(type, "#")) // metaclass
     {
         void *pointer;
 

--- a/Tests/Definition/TyphoonInjectionDefinitionTests.m
+++ b/Tests/Definition/TyphoonInjectionDefinitionTests.m
@@ -12,6 +12,7 @@
 #import <XCTest/XCTest.h>
 #import "MiddleAgesAssembly.h"
 #import "Knight.h"
+#import "RectModel.h"
 
 @interface TyphoonInjectionDefinitionTests : XCTestCase
 
@@ -73,6 +74,13 @@
 
     NSNumber*(^block)(void) = ^{ return @1; };
     XCTAssertEqualObjects(((id(^)(void))[_assembly simpleRuntimeArgument:block])(), @1);
+}
+
+- (void)test_primitive_definition_component
+{
+    RectModel *rectModel = [_assembly rectModel];
+    XCTAssertNotEqual([NSValue valueWithCGRect:rectModel.rectFrame],
+                      [NSValue valueWithCGRect:CGRectZero]);
 }
 
 @end

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.h
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.h
@@ -24,6 +24,8 @@
 
 @property (nonatomic, strong, readonly) CollaboratingMiddleAgesAssembly *collaboratingAssembly;
 
+- (id)rectModel;
+
 - (id)knight;
 
 - (id)cavalryMan;

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
@@ -22,8 +22,26 @@
 #import "Mock.h"
 #import "TyphoonInject.h"
 #import "CollaboratingMiddleAgesAssembly.h"
+#import "RectModel.h"
 
 @implementation MiddleAgesAssembly
+
+- (id)rectModel
+{
+    return [TyphoonDefinition withClass:[RectModel class] configuration:^(TyphoonDefinition *definition) {
+        [definition injectProperty:@selector(rectFrame) with:[self mainScreenBounds]];
+    }];
+}
+
+- (UIScreen *)mainScreen
+{
+    return [TyphoonDefinition withFactory:[UIScreen class] selector:@selector(mainScreen)];
+}
+
+- (NSValue *)mainScreenBounds
+{
+    return [TyphoonDefinition withFactory:[self mainScreen] selector:@selector(bounds)];
+}
 
 - (id)knight
 {

--- a/Tests/Model/RectModel.h
+++ b/Tests/Model/RectModel.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  RectModel.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Igor Vasilenko on 13/06/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
 

--- a/Tests/Model/RectModel.h
+++ b/Tests/Model/RectModel.h
@@ -1,0 +1,15 @@
+//
+//  RectModel.h
+//  Typhoon
+//
+//  Created by Igor Vasilenko on 13/06/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RectModel : NSObject
+
+@property (assign, nonatomic) CGRect rectFrame;
+
+@end

--- a/Tests/Model/RectModel.m
+++ b/Tests/Model/RectModel.m
@@ -1,0 +1,13 @@
+//
+//  RectModel.m
+//  Typhoon
+//
+//  Created by Igor Vasilenko on 13/06/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import "RectModel.h"
+
+@implementation RectModel
+
+@end

--- a/Tests/Model/RectModel.m
+++ b/Tests/Model/RectModel.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  RectModel.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Igor Vasilenko on 13/06/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "RectModel.h"
 

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -619,6 +619,8 @@
 		A56819081AA9462F00ECC4F9 /* Typhoon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90ABC3EA1A36B09E008D8162 /* Typhoon.framework */; };
 		A56819091AA9462F00ECC4F9 /* Typhoon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 90ABC3EA1A36B09E008D8162 /* Typhoon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A568191A1AA960A400ECC4F9 /* TyphoonAssemblyActivator.m in Sources */ = {isa = PBXBuildFile; fileRef = BA79842846CF608977332EB1 /* TyphoonAssemblyActivator.m */; };
+		B7F7B3271D0E210C003D1AB4 /* RectModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B7F7B3261D0E210C003D1AB4 /* RectModel.m */; };
+		B7F7B3281D0E210C003D1AB4 /* RectModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B7F7B3261D0E210C003D1AB4 /* RectModel.m */; };
 		BA79800CECE8B23578FA08B1 /* TyphoonAssemblyAdviser.m in Sources */ = {isa = PBXBuildFile; fileRef = BA798CAB2EE92B9A572C7DDF /* TyphoonAssemblyAdviser.m */; };
 		BA79802CB7E65F6E28932349 /* TyphoonBlockComponentFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA798AEA7455E7FC00A4E494 /* TyphoonBlockComponentFactoryTests.m */; };
 		BA79806A52A10605DC97BDF9 /* CavalryMan.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B0770331936F63A0083714E /* CavalryMan.m */; };
@@ -1411,6 +1413,8 @@
 		9FFB52561BA152FF0078F6B2 /* TyphoonSingleAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonSingleAssembly.m; sourceTree = "<group>"; };
 		A56819151AA94E6200ECC4F9 /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = "<group>"; };
 		A56819161AA951DE00ECC4F9 /* PrefixTests.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefixTests.pch; sourceTree = "<group>"; };
+		B7F7B3251D0E210C003D1AB4 /* RectModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RectModel.h; sourceTree = "<group>"; };
+		B7F7B3261D0E210C003D1AB4 /* RectModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RectModel.m; sourceTree = "<group>"; };
 		BA79802001176CAE1C666D5B /* TyphoonAssemblyActivator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonAssemblyActivator.h; sourceTree = "<group>"; };
 		BA79809B312F99BCEDF489BD /* TyphoonNSNumberTypeConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonNSNumberTypeConverter.m; sourceTree = "<group>"; };
 		BA7980A75A6786BBC2A387F9 /* UniqueViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UniqueViewController.m; sourceTree = "<group>"; };
@@ -2438,6 +2442,8 @@
 				C949792A85FC9383BEAD631B /* Mock.m */,
 				C949758EA994B0137DD95E6D /* Mock.h */,
 				2DBA1563B09BB6CE82F164EE /* AutoInjection */,
+				B7F7B3251D0E210C003D1AB4 /* RectModel.h */,
+				B7F7B3261D0E210C003D1AB4 /* RectModel.m */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3500,6 +3506,7 @@
 				BA7985E9B7C3C34D17FC40FD /* TyphoonNSNumberTypeConverter.m in Sources */,
 				BA798EF5AD7AC635BDD727C0 /* NSNullTypeConverter.m in Sources */,
 				2DBA14431D350F4F142A0E3B /* TyphoonFactoryDefinition.m in Sources */,
+				B7F7B3271D0E210C003D1AB4 /* RectModel.m in Sources */,
 				8946F2E01B8E403E005C4954 /* TyphoonViewHelpers.m in Sources */,
 				0183B75C1C827DD100644B62 /* TyphoonBlockDefinition.m in Sources */,
 				2DBA13903A06BF4A2A8C60CD /* TyphoonOptionMatcher.m in Sources */,
@@ -3528,6 +3535,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6B0770F31936FEA80083714E /* AssemblyWithDefinitionConfiguration.m in Sources */,
+				B7F7B3281D0E210C003D1AB4 /* RectModel.m in Sources */,
 				6B0770F41936FEA80083714E /* DefinitionConfigurationTest.m in Sources */,
 				6B0770F71936FEA80083714E /* TyphoonBundleResourceTests.m in Sources */,
 				6B0770F81936FEA80083714E /* TyphoonComponentFactoryPostProcessorStubImpl.m in Sources */,


### PR DESCRIPTION
This PR solving [issue](https://github.com/appsquickly/Typhoon/issues/456)
As a result, in TCFWrapValues category of NSInvocation was implemented method that returns returnValue of current invocation and wrap primitive value if needed. 
And used for `resultOfInvokingOn:`, because if function `[self getReturnValue:]` returns primitive value, id type is will be wrong. 

Tests for this case will be implemented as soon.