### PR TITLE
Changed the logic respondToSelector in TyphoonBlockComponentFactory

### DIFF
--- a/Source/Factory/Internal/TyphoonBlockComponentFactory.m
+++ b/Source/Factory/Internal/TyphoonBlockComponentFactory.m
@@ -146,4 +146,19 @@
     return [TyphoonIntrospectionUtils methodSignatureWithArgumentsAndReturnValueAsObjectsFromSelector:aSelector];
 }
 
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if ([super respondsToSelector:aSelector]){
+        return YES;
+    }
+    
+    NSString *key = NSStringFromSelector(aSelector);
+    TyphoonDefinition *definition = [self definitionForKey:key];
+    
+    if (definition) {
+        return YES;
+    }
+    return NO;
+}
+
 @end


### PR DESCRIPTION
In my case, its need for the test that factory is correctly injected and its selectors contains in TyphoonBlockComponentFactory.

If  TyphoonBlockComponentFactory doesn't respondToSelector, try to check that one of the TyphoonDefinition could respondToSelector.
