### PR TITLE
#456-Wrapping primitive values NSInvocation

### DIFF
--- a/Source/Factory/Internal/NSInvocation+TCFInstanceBuilder.m
+++ b/Source/Factory/Internal/NSInvocation+TCFInstanceBuilder.m
@@ -10,6 +10,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #import "NSInvocation+TCFInstanceBuilder.h"
+#import "NSInvocation+TCFWrapValues.h"
 
 #if __has_feature(objc_arc)
 #error You have to disable ARC for this file
@@ -50,11 +51,10 @@ static BOOL typhoon_IsSelectorReturnsRetained(SEL selector) {
 
 - (id)typhoon_resultOfInvokingOn:(id)instanceOrClass NS_RETURNS_RETAINED
 {
-    id returnValue = nil;
+    [self invokeWithTarget:instanceOrClass];
+    id returnValue = [self typhoon_getReturnValue];
 
     BOOL isReturnsRetained = typhoon_IsSelectorReturnsRetained([self selector]);
-    [self invokeWithTarget:instanceOrClass];
-    [self getReturnValue:&returnValue];
     if (!isReturnsRetained) {
         [returnValue retain]; /* Retain to take ownership on autoreleased object */
     }

--- a/Source/Factory/Internal/NSInvocation+TCFWrapValues.h
+++ b/Source/Factory/Internal/NSInvocation+TCFWrapValues.h
@@ -17,4 +17,7 @@
 /** Get argument at index, wrapping primitive values in NSValue if needed */
 - (id)typhoon_getArgumentObjectAtIndex:(NSInteger)idx;
 
+/** Get return value, wrapping primitive values in NSValue if needed */
+- (id)typhoon_getReturnValue;
+
 @end

--- a/Tests/Definition/TyphoonInjectionDefinitionTests.m
+++ b/Tests/Definition/TyphoonInjectionDefinitionTests.m
@@ -12,6 +12,7 @@
 #import <XCTest/XCTest.h>
 #import "MiddleAgesAssembly.h"
 #import "Knight.h"
+#import "RectModel.h"
 
 @interface TyphoonInjectionDefinitionTests : XCTestCase
 
@@ -73,6 +74,13 @@
 
     NSNumber*(^block)(void) = ^{ return @1; };
     XCTAssertEqualObjects(((id(^)(void))[_assembly simpleRuntimeArgument:block])(), @1);
+}
+
+- (void)test_primitive_definition_component
+{
+    RectModel *rectModel = [_assembly rectModel];
+    XCTAssertNotEqual([NSValue valueWithCGRect:rectModel.rectFrame],
+            [NSValue valueWithCGRect:CGRectZero]);
 }
 
 @end

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.h
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.h
@@ -122,4 +122,6 @@
 
 - (id)notSoBlockKnight;
 
+- (id)rectModel;
+
 @end

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
@@ -22,6 +22,7 @@
 #import "Mock.h"
 #import "TyphoonInject.h"
 #import "CollaboratingMiddleAgesAssembly.h"
+#import "RectModel.h"
 
 @implementation MiddleAgesAssembly
 
@@ -436,11 +437,11 @@
 {
     return [TyphoonBlockDefinition withClass:[Knight class] initializer:^id{
         return [[Knight alloc] initWithQuest:[self defaultQuest]];
-        
+
     } injections:^(Knight *knight) {
         knight.damselsRescued = 42;
         [knight setFoobar:@(123) andHasHorse:YES friends:nil];
-        
+
     } configuration:^(TyphoonDefinition *definition) {
         definition.scope = TyphoonScopeWeakSingleton;
     }];
@@ -473,7 +474,7 @@
     return [TyphoonBlockDefinition withClass:[Knight class] block:^id{
         Knight *knight = [[Knight alloc] init];
         knight.favoriteDamsels = favoriteDamsels;
-        knight.quest = [self blockQuestWithURL:questURL];        
+        knight.quest = [self blockQuestWithURL:questURL];
         return knight;
     }];
 }
@@ -508,7 +509,7 @@
 {
     return [TyphoonBlockDefinition withInitializer:^id{
         return [[Knight alloc] initWithDamselsRescued:123 foo:nil];
-        
+
     } injections:^(Knight *instance) {
         instance.quest = [self blockQuestForKnightWithCircularDependency];
     }];
@@ -518,7 +519,7 @@
 {
     return [TyphoonBlockDefinition withInitializer:^id{
         return [[DamselQuest alloc] init];
-        
+
     } injections:^(DamselQuest *instance) {
         instance.bounty = ((Knight *)[self blockKnightWithCircularDependency]).damselsRescued;
     }];
@@ -541,6 +542,23 @@
         }];
         [definition injectProperty:@selector(damselsRescued) with:@(12)];
     }];
+}
+
+- (id)rectModel
+{
+    return [TyphoonDefinition withClass:[RectModel class] configuration:^(TyphoonDefinition *definition) {
+        [definition injectProperty:@selector(rectFrame) with:[self mainScreenBounds]];
+    }];
+}
+
+- (UIScreen *)mainScreen
+{
+    return [TyphoonDefinition withFactory:[UIScreen class] selector:@selector(mainScreen)];
+}
+
+- (NSValue *)mainScreenBounds
+{
+    return [TyphoonDefinition withFactory:[self mainScreen] selector:@selector(bounds)];
 }
 
 @end

--- a/Tests/Model/RectModel.h
+++ b/Tests/Model/RectModel.h
@@ -1,0 +1,18 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@interface RectModel : NSObject
+
+@property (assign, nonatomic) CGRect rectFrame;
+
+@end

--- a/Tests/Model/RectModel.m
+++ b/Tests/Model/RectModel.m
@@ -1,0 +1,15 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "RectModel.h"
+
+@implementation RectModel
+@end

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		74AD335F374ECC3FD0E34729 /* StoryboardTabBarSecondViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD31DCF1D597D6212D587A /* StoryboardTabBarSecondViewController.m */; };
 		74AD351B362D3B39E43832A0 /* StoryboardTabBarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD399EBA963C9A8C485A76 /* StoryboardTabBarViewController.m */; };
 		74AD3619DC60B184679A6EFE /* Model.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD382C1698D7B4E78A2E42 /* Model.m */; };
+		74AD3799741B915315903C70 /* RectModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD3F0957BBA795250E1CAD /* RectModel.m */; };
 		74AD3878376497F3DE81296F /* StoryboardWithReferenceAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD3381608371B09052C354 /* StoryboardWithReferenceAssembly.m */; };
 		74AD38DC07ADFDAAC4B2BA22 /* Model.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD382C1698D7B4E78A2E42 /* Model.m */; };
 		74AD3A1E495375915555E628 /* StoryboardTabBarFirstViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74AD391E6F16EF3B9F07BDC6 /* StoryboardTabBarFirstViewController.m */; };
@@ -1376,6 +1377,8 @@
 		74AD382C1698D7B4E78A2E42 /* Model.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Model.m; sourceTree = "<group>"; };
 		74AD391E6F16EF3B9F07BDC6 /* StoryboardTabBarFirstViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoryboardTabBarFirstViewController.m; sourceTree = "<group>"; };
 		74AD399EBA963C9A8C485A76 /* StoryboardTabBarViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoryboardTabBarViewController.m; sourceTree = "<group>"; };
+		74AD3E3B22E9A37E861C75B9 /* RectModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RectModel.h; sourceTree = "<group>"; };
+		74AD3F0957BBA795250E1CAD /* RectModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RectModel.m; sourceTree = "<group>"; };
 		74AD3F0F83C575EBDE180F1D /* StoryboardWithReferenceAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StoryboardWithReferenceAssembly.h; sourceTree = "<group>"; };
 		8946F2DC1B8E3F44005C4954 /* TyphoonViewHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonViewHelpersTests.m; sourceTree = "<group>"; };
 		8946F2DE1B8E403E005C4954 /* TyphoonViewHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonViewHelpers.h; sourceTree = "<group>"; };
@@ -2464,6 +2467,8 @@
 				C949792A85FC9383BEAD631B /* Mock.m */,
 				C949758EA994B0137DD95E6D /* Mock.h */,
 				2DBA1563B09BB6CE82F164EE /* AutoInjection */,
+				74AD3F0957BBA795250E1CAD /* RectModel.m */,
+				74AD3E3B22E9A37E861C75B9 /* RectModel.h */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3708,6 +3713,7 @@
 				74AD335F374ECC3FD0E34729 /* StoryboardTabBarSecondViewController.m in Sources */,
 				74AD38DC07ADFDAAC4B2BA22 /* Model.m in Sources */,
 				74AD3878376497F3DE81296F /* StoryboardWithReferenceAssembly.m in Sources */,
+				74AD3799741B915315903C70 /* RectModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR solving [issue](https://github.com/appsquickly/Typhoon/issues/456)
As a result, in TCFWrapValues category of NSInvocation was implemented method that returns returnValue of current invocation and wrap primitive value if needed. 
And used for `resultOfInvokingOn:`, because if function `[self getReturnValue:]` returns primitive value, id type is will be wrong. 