### PR TITLE
Fixed bundle resource in setAppDelegate swizzling via Carthage

### DIFF
--- a/Source/Configuration/Startup/TyphoonStartup.m
+++ b/Source/Configuration/Startup/TyphoonStartup.m
@@ -109,7 +109,7 @@ static BOOL initialFactoryWasCreated = NO;
         }
         if (initialFactory) {
             TyphoonGlobalConfigCollector *collector = [[TyphoonGlobalConfigCollector alloc] initWithAppDelegate:delegate];
-            NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+            NSBundle *bundle = [NSBundle bundleForClass:[delegate class]];
             NSArray *globalConfigFileNames = [collector obtainGlobalConfigFilenamesFromBundle:bundle];
             for (NSString *configName in globalConfigFileNames) {
                 id<TyphoonDefinitionPostProcessor> configProcessor = [TyphoonConfigPostProcessor forResourceNamed:configName inBundle:bundle];


### PR DESCRIPTION
PR solving #508 issue.

As a result, ```+ (void)swizzleSetDelegateMethodOnApplicationClass``` was fixed by changing bundle class.

@alexgarbarev need write tests for this case?