### PR TITLE
Fixed the problem discussed in issues 513

### DIFF
--- a/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.h
+++ b/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.h
@@ -1,0 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <UIKit/UIKit.h>
+
+@interface NSLayoutConstraint (TyphoonOutletTransfer)
+
+// Identifier for compare constraints for transfer
+@property (nonatomic, strong) NSString *typhoonTransferIdentifier;
+
+// Retain constraint from TyphoonLoadedView
+@property (nonatomic, strong) NSLayoutConstraint *typhoonTransferConstraint;
+
+@end

--- a/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.h
+++ b/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2015, Typhoon Framework Contributors
+//  Copyright 2016, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.m
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "NSLayoutConstraint+TyphoonOutletTransfer.h"
+#import <objc/runtime.h>
+
+@implementation NSLayoutConstraint (TyphoonOutletTransfer)
+
+- (void)setTyphoonTransferIdentifier:(NSString *)identifier {
+    objc_setAssociatedObject(self, @selector(typhoonTransferIdentifier), identifier, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSString *)typhoonTransferIdentifier {
+    return objc_getAssociatedObject(self, @selector(typhoonTransferIdentifier));
+}
+
+- (void)setTyphoonTransferConstraint:(NSLayoutConstraint *)typhoonTransferConstraint {
+    objc_setAssociatedObject(self, @selector(typhoonTransferConstraint), typhoonTransferConstraint, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSLayoutConstraint *)typhoonTransferConstraint {
+    return objc_getAssociatedObject(self, @selector(typhoonTransferConstraint));
+}
+
+@end

--- a/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/NSLayoutConstraint+TyphoonOutletTransfer.m
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2015, Typhoon Framework Contributors
+//  Copyright 2016, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/ios/Storyboard/TyphoonLoadedView.m
+++ b/Source/ios/Storyboard/TyphoonLoadedView.m
@@ -12,7 +12,7 @@
 
 #import "TyphoonLoadedView.h"
 #import "TyphoonViewHelpers.h"
-
+#import "UIView+TyphoonOutletTransfer.h"
 #import <objc/runtime.h>
 
 @implementation TyphoonLoadedView
@@ -24,7 +24,7 @@
 
 - (id)awakeAfterUsingCoder:(NSCoder *)aDecoder
 {
-    id replacement = [TyphoonViewHelpers viewFromDefinition:[self typhoonKey] originalView:self];
+    UIView *replacement = [TyphoonViewHelpers viewFromDefinition:[self typhoonKey] originalView:self];
     if (replacement != self) {
         /**
          * Coupling view loaded from Xib with replacement loaded from Typhoon
@@ -34,6 +34,7 @@
          * */
         objc_setAssociatedObject(replacement, "TyphoonXibPrototype", self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
+    replacement.typhoonNeedTransferOutlets = YES;
     return replacement;
 }
 

--- a/Source/ios/Storyboard/TyphoonViewHelpers.m
+++ b/Source/ios/Storyboard/TyphoonViewHelpers.m
@@ -11,6 +11,7 @@
 
 #import "TyphoonViewHelpers.h"
 #import "TyphoonStoryboard.h"
+#import "NSLayoutConstraint+TyphoonOutletTransfer.h"
 #import "OCLogTemplate.h"
 
 @implementation TyphoonViewHelpers
@@ -42,7 +43,6 @@
         BOOL replaceSecondItem = [constraint secondItem] == src;
         id firstItem = replaceFirstItem ? dst : constraint.firstItem;
         id secondItem = replaceSecondItem ? dst : constraint.secondItem;
-        // Use the same constraint instance that the external outlets
         NSLayoutConstraint *newConstraint = [NSLayoutConstraint constraintWithItem:firstItem
                                                                          attribute:constraint.firstAttribute
                                                                          relatedBy:constraint.relation
@@ -51,6 +51,12 @@
                                                                         multiplier:constraint.multiplier
                                                                           constant:constraint.constant];
         newConstraint.priority = constraint.priority;
+        
+        NSString *typhoonTransferIdentifier = [[NSUUID UUID] UUIDString];
+        constraint.typhoonTransferIdentifier = typhoonTransferIdentifier;
+        newConstraint.typhoonTransferIdentifier = typhoonTransferIdentifier;
+        newConstraint.typhoonTransferConstraint = constraint;
+
         [dst addConstraint:newConstraint];
     }
     

--- a/Source/ios/Storyboard/UIResponder+TyphoonOutletTransfer.h
+++ b/Source/ios/Storyboard/UIResponder+TyphoonOutletTransfer.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2015, Typhoon Framework Contributors
+//  Copyright 2016, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file
@@ -13,6 +13,6 @@
 
 @interface UIResponder (TyphoonOutletTransfer)
 
-- (void)transferFromView:(UIView *)view;
+- (void)transferConstraintsFromView:(UIView *)view;
 
 @end

--- a/Source/ios/Storyboard/UIResponder+TyphoonOutletTransfer.h
+++ b/Source/ios/Storyboard/UIResponder+TyphoonOutletTransfer.h
@@ -1,0 +1,18 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <UIKit/UIKit.h>
+
+@interface UIResponder (TyphoonOutletTransfer)
+
+- (void)transferFromView:(UIView *)view;
+
+@end

--- a/Source/ios/Storyboard/UIResponder+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIResponder+TyphoonOutletTransfer.m
@@ -1,0 +1,126 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "UIResponder+TyphoonOutletTransfer.h"
+#import "NSLayoutConstraint+TyphoonOutletTransfer.h"
+#import <objc/runtime.h>
+
+@implementation UIResponder (TyphoonOutletTransfer)
+
+- (void)transferFromView:(UIView *)view
+{
+    unsigned count;
+    objc_property_t *properties = class_copyPropertyList([self class], &count);
+    unsigned i;
+    for (i = 0; i < count; i++) {
+        objc_property_t property = properties[i];
+        const char *propName = property_getName(property);
+        if(propName) {
+            NSString *propertyName = [NSString stringWithCString:propName
+                                                        encoding:[NSString defaultCStringEncoding]];
+            const char *propertyAttributes = property_getAttributes(property);
+            const char *propType = getPropertyType(propertyAttributes);
+            NSString *propertyType = [NSString stringWithCString:propType
+                                                        encoding:[NSString defaultCStringEncoding]];
+            BOOL isReadonly = isReadonlyProperty(propertyAttributes);
+            if (!isReadonly && [self respondsToSelector:NSSelectorFromString(propertyName)]) {
+                // IBOutlet
+                if (NSClassFromString(propertyType) == [NSLayoutConstraint class]) {
+                    [self transferConstraintOutletForKey:propertyName
+                                                fromView:view];
+                }
+                // IBOutlet​Collection
+                if ([NSClassFromString(propertyType) isSubclassOfClass:[NSArray class]]) {
+                    [self transferConstraintOutletsForKey:propertyName
+                                                 fromView:view];
+                }
+            }
+        }
+    }
+    free(properties);
+}
+
+- (void)transferConstraintOutletForKey:(NSString *)propertyName
+                              fromView:(UIView *)view
+{
+    NSLayoutConstraint *constraint = [self valueForKey:propertyName];
+    if (constraint.typhoonTransferIdentifier) {
+        for (NSLayoutConstraint *transferConstraint in view.constraints) {
+            BOOL equalObjects = constraint == transferConstraint;
+            BOOL equalIdentifier = [constraint.typhoonTransferIdentifier isEqualToString:transferConstraint.typhoonTransferIdentifier];
+            if (!equalObjects && equalIdentifier) {
+                [self setValue:transferConstraint
+                        forKey:propertyName];
+            }
+        }
+    }
+}
+
+- (void)transferConstraintOutletsForKey:(NSString *)propertyName
+                               fromView:(UIView *)view
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self isKindOfClass: %@",
+                              [NSLayoutConstraint class]];
+    NSArray *constraints = [self valueForKey:propertyName];
+    NSArray *filtered = [constraints filteredArrayUsingPredicate:predicate];
+    if (filtered.count > 0) {
+        BOOL needChange = NO;
+        NSMutableArray *newOutlets = [NSMutableArray new];
+        for (id outlet in constraints) {
+            id changeOutlet = outlet;
+            if ([outlet isMemberOfClass:[NSLayoutConstraint class]]) {
+                NSLayoutConstraint *constraint = outlet;
+                if (constraint.typhoonTransferIdentifier) {
+                    for (NSLayoutConstraint *transferConstraint in view.constraints) {
+                        BOOL equalObjects = constraint == transferConstraint;
+                        BOOL equalIdentifier = [constraint.typhoonTransferIdentifier isEqualToString:transferConstraint.typhoonTransferIdentifier];
+                        if (!equalObjects && equalIdentifier) {
+                            changeOutlet = transferConstraint;
+                            needChange = YES;
+                        }
+                    }
+                }
+            }
+            [newOutlets addObject:changeOutlet];
+        }
+        
+        if (needChange) {
+            [self setValue:newOutlets
+                    forKey:propertyName];
+        }
+        
+    }
+}
+
+static const char *getPropertyType(const char * attributes)
+{
+    char buffer[1 + strlen(attributes)];
+    strlcpy(buffer, attributes, sizeof(buffer));
+    char *state = buffer, *attribute;
+    while ((attribute = strsep(&state, ",")) != NULL) {
+        if (attribute[0] == 'T') {
+            if (strlen(attribute) <= 4) {
+                break;
+            }
+            return (const char *)[[NSData dataWithBytes:(attribute + 3) length:strlen(attribute) - 4] bytes];
+        }
+    }
+    return "@";
+}
+
+static BOOL isReadonlyProperty(const char * propertyAttributes)
+{
+    NSArray *attributes = [[NSString stringWithUTF8String:propertyAttributes]
+                           componentsSeparatedByString:@","];
+    return [attributes containsObject:@"R"];
+}
+
+@end

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.h
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.h
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (TyphoonOutletTransfer)
+
+// Flag to check whether the outlets constraint transportation needs
+@property (nonatomic, assign) BOOL typhoonNeedTransferOutlets;
+
+@end

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.h
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2015, Typhoon Framework Contributors
+//  Copyright 2016, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
@@ -70,6 +70,11 @@
 {
     [self transferFromView:transferView];
     
+    // Optimization. The outlet from view to the subview of TyphoonLoadedView is invalid.
+    if (view == transferView) {
+        return;
+    }
+    
     for (UIView *subview in view.subviews) {
         [subview transferOutlets:subview
                     transferView:transferView];
@@ -187,11 +192,28 @@
 
 - (UIView *)findRootView:(UIView *)view
 {
-    if (view.superview) {
+    NSArray *expulsionViewClasses = [self expulsionViewClasses];
+    // Optimization. The outlet from view to the UICollectionViewCell is invalid.
+    // Outlets cannot be connected to repeating content.
+    BOOL expulsion = NO;
+    for (Class expulsionClass in expulsionViewClasses) {
+        if ([view isKindOfClass:expulsionClass]) {
+            expulsion = YES;
+        }
+    }
+
+    if (view.superview && !expulsion) {
         return [view.superview findRootView:view.superview];
     }
     return view;
 }
+
+- (NSArray *)expulsionViewClasses
+{
+    return @[[UITableViewCell class],
+             [UICollectionViewCell class]];
+}
+
 
 static const char *getPropertyType(const char * attributes)
 {

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
@@ -138,7 +138,7 @@
 - (void)transferConstraintOutletsForKey:(NSString *)propertyName
                              fromView:(UIView *)view
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@",
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self isKindOfClass: %@",
                               [NSLayoutConstraint class]];
     NSArray *constraints = [self valueForKey:propertyName];
     NSArray *filtered = [constraints filteredArrayUsingPredicate:predicate];

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPHOON FRAMEWORK
-//  Copyright 2015, Typhoon Framework Contributors
+//  Copyright 2016, Typhoon Framework Contributors
 //  All Rights Reserved.
 //
 //  NOTICE: The authors permit you to use, modify, and distribute this file
@@ -62,7 +62,7 @@
         // Change UIViewController outlets properties
         UIResponder *nextRexponder = [rootView nextResponder];
         if ([nextRexponder isKindOfClass:[UIViewController class]]) {
-            [nextRexponder transferFromView:self];
+            [nextRexponder transferConstraintsFromView:self];
         }
         
         // recursive check and change super outlets properties
@@ -76,7 +76,7 @@
 - (void)transferOutlets:(UIView *)view
            transferView:(UIView *)transferView
 {
-    [view transferFromView:transferView];
+    [view transferConstraintsFromView:transferView];
     
     // Optimization. The outlet from view to the subview of TyphoonLoadedView is invalid.
     if (view == transferView) {

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
@@ -26,15 +26,16 @@
 }
 
 
-// Swizzle didMoveToWindow
+// Swizzle awakeFromNib
+// After the [super awakeFromNib] all the outlets on view will be setted
 + (void)load
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         Class class = [self class];
         
-        SEL originalSelector = @selector(didMoveToWindow);
-        SEL swizzledSelector = @selector(typhoon_didMoveToWindow);
+        SEL originalSelector = @selector(awakeFromNib);
+        SEL swizzledSelector = @selector(typhoon_awakeFromNib);
         
         Method originalMethod = class_getInstanceMethod(class, originalSelector);
         Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
@@ -50,9 +51,9 @@
     });
 }
 
-- (void)typhoon_didMoveToWindow
+- (void)typhoon_awakeFromNib
 {
-    [self typhoon_didMoveToWindow];
+    [self typhoon_awakeFromNib];
     // When view have superview transfer outlets if needed
     if (self.typhoonNeedTransferOutlets) {
         // recursive search of root view (superview without superview)

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
@@ -1,0 +1,198 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  TYPHOON FRAMEWORK
+//  Copyright 2015, Typhoon Framework Contributors
+//  All Rights Reserved.
+//
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#import "UIView+TyphoonOutletTransfer.h"
+#import "NSLayoutConstraint+TyphoonOutletTransfer.h"
+#import <objc/runtime.h>
+
+@implementation UIView (TyphoonOutletTransfer)
+
+- (void)setTyphoonNeedTransferOutlets:(BOOL)typhoonNeedTransferOutlets {
+    objc_setAssociatedObject(self, @selector(typhoonNeedTransferOutlets), @(typhoonNeedTransferOutlets), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)typhoonNeedTransferOutlets {
+    return [objc_getAssociatedObject(self, @selector(typhoonNeedTransferOutlets)) boolValue];
+}
+
+
+// Swizzle didMoveToWindow
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(didMoveToWindow);
+        SEL swizzledSelector = @selector(typhoon_didMoveToWindow);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        BOOL didAddMethod = class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+- (void)typhoon_didMoveToWindow {
+    [self typhoon_didMoveToWindow];
+    // When view have superview transfer outlets if needed
+    if (self.typhoonNeedTransferOutlets) {
+        // recursive search of root view (superview without superview)
+        UIView *rootView = [self findRootView:self];
+        // recursive check and change outlets properties
+        [self transferOutlets:rootView
+                 transferView:self];
+        // Mark that the transportation of finished
+        self.typhoonNeedTransferOutlets = NO;
+    }    
+}
+
+- (void)transferOutlets:(UIView *)view
+           transferView:(UIView *)transferView {
+    
+    [self transferFromView:transferView];
+    
+    for (UIView *subview in view.subviews) {
+        [subview transferOutlets:subview
+                    transferView:transferView];
+    }
+}
+
+- (void)transferFromView:(UIView *)view {
+    
+    unsigned count;
+    objc_property_t *properties = class_copyPropertyList([self class], &count);
+    
+    unsigned i;
+    for (i = 0; i < count; i++) {
+        
+        objc_property_t property = properties[i];
+        const char *propName = property_getName(property);
+        
+        if(propName) {
+            
+            const char *propType = getPropertyType(property);
+            NSString *propertyName = [NSString stringWithCString:propName
+                                                        encoding:[NSString defaultCStringEncoding]];
+            NSString *propertyType = [NSString stringWithCString:propType
+                                                        encoding:[NSString defaultCStringEncoding]];
+            // IBOutlet
+            if (NSClassFromString(propertyType) == [NSLayoutConstraint class]) {
+                [self transferConstraintOutletForKey:propertyName
+                                           fromView:view];
+            }
+            // IBOutlet​Collection
+            if ([NSClassFromString(propertyType) isSubclassOfClass:[NSArray class]]) {
+                [self transferConstraintOutletsForKey:propertyName
+                                             fromView:view];
+            }
+            
+        }
+        
+    }
+    
+    free(properties);
+}
+
+- (void)transferConstraintOutletForKey:(NSString *)propertyName
+                             fromView:(UIView *)view {
+    NSLayoutConstraint *constraint = [self valueForKey:propertyName];
+    if (constraint.typhoonTransferIdentifier) {
+        for (NSLayoutConstraint *transferConstraint in view.constraints) {
+            BOOL equalObjects = constraint == transferConstraint;
+            BOOL equalIdentifier = [constraint.typhoonTransferIdentifier isEqualToString:transferConstraint.typhoonTransferIdentifier];
+            if (!equalObjects && equalIdentifier) {
+                [self setValue:transferConstraint
+                        forKey:propertyName];
+            }
+        }
+    }
+}
+
+- (void)transferConstraintOutletsForKey:(NSString *)propertyName
+                             fromView:(UIView *)view {
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@",
+                              [NSLayoutConstraint class]];
+    NSArray *constraints = [self valueForKey:propertyName];
+    NSArray *filtered = [constraints filteredArrayUsingPredicate:predicate];
+    
+    if (filtered.count > 0) {
+        
+        BOOL needChange = NO;
+        NSMutableArray *newOutlets = [NSMutableArray new];
+        
+        for (id outlet in constraints) {
+            
+            id changeOutlet = outlet;
+
+            if ([outlet isMemberOfClass:[NSLayoutConstraint class]]) {
+        
+                NSLayoutConstraint *constraint = outlet;
+                
+                if (constraint.typhoonTransferIdentifier) {
+                    
+                    for (NSLayoutConstraint *transferConstraint in view.constraints) {
+                        
+                        BOOL equalObjects = constraint == transferConstraint;
+                        BOOL equalIdentifier = [constraint.typhoonTransferIdentifier isEqualToString:transferConstraint.typhoonTransferIdentifier];
+                        
+                        if (!equalObjects && equalIdentifier) {
+                            changeOutlet = transferConstraint;
+                            needChange = YES;
+                        }
+                        
+                    }
+                    
+                }
+            }
+            
+            [newOutlets addObject:changeOutlet];
+            
+        }
+        
+        if (needChange) {
+            [self setValue:newOutlets
+                    forKey:propertyName];
+        }
+        
+    }
+}
+
+static const char *getPropertyType(objc_property_t property) {
+    const char *attributes = property_getAttributes(property);
+    char buffer[1 + strlen(attributes)];
+    strlcpy(buffer, attributes, sizeof(buffer));
+    char *state = buffer, *attribute;
+    while ((attribute = strsep(&state, ",")) != NULL) {
+        if (attribute[0] == 'T') {
+            if (strlen(attribute) <= 4) {
+                break;
+            }
+            return (const char *)[[NSData dataWithBytes:(attribute + 3) length:strlen(attribute) - 4] bytes];
+        }
+    }
+    return "@";
+}
+
+- (UIView *)findRootView:(UIView *)view {
+    if (view.superview) {
+        return [view.superview findRootView:view.superview];
+    }
+    return view;
+}
+
+@end

--- a/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
+++ b/Source/ios/Storyboard/UIView+TyphoonOutletTransfer.m
@@ -10,7 +10,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #import "UIView+TyphoonOutletTransfer.h"
-#import "NSLayoutConstraint+TyphoonOutletTransfer.h"
+#import "UIResponder+TyphoonOutletTransfer.h"
 #import <objc/runtime.h>
 
 @implementation UIView (TyphoonOutletTransfer)
@@ -57,7 +57,14 @@
     if (self.typhoonNeedTransferOutlets) {
         // recursive search of root view (superview without superview)
         UIView *rootView = [self findRootView:self];
-        // recursive check and change outlets properties
+        
+        // Change UIViewController outlets properties
+        UIResponder *nextRexponder = [rootView nextResponder];
+        if ([nextRexponder isKindOfClass:[UIViewController class]]) {
+            [nextRexponder transferFromView:self];
+        }
+        
+        // recursive check and change super outlets properties
         [self transferOutlets:rootView
                  transferView:self];
         // Mark that the transportation of finished
@@ -68,7 +75,7 @@
 - (void)transferOutlets:(UIView *)view
            transferView:(UIView *)transferView
 {
-    [self transferFromView:transferView];
+    [view transferFromView:transferView];
     
     // Optimization. The outlet from view to the subview of TyphoonLoadedView is invalid.
     if (view == transferView) {
@@ -81,128 +88,23 @@
     }
 }
 
-- (void)transferFromView:(UIView *)view
-{
-    unsigned count;
-    objc_property_t *properties = class_copyPropertyList([self class], &count);
-    
-    unsigned i;
-    for (i = 0; i < count; i++) {
-        
-        objc_property_t property = properties[i];
-        const char *propName = property_getName(property);
-        
-        if(propName) {
-            
-            NSString *propertyName = [NSString stringWithCString:propName
-                                                        encoding:[NSString defaultCStringEncoding]];
-            const char *propertyAttributes = property_getAttributes(property);
-            const char *propType = getPropertyType(propertyAttributes);
-            NSString *propertyType = [NSString stringWithCString:propType
-                                                        encoding:[NSString defaultCStringEncoding]];
-            BOOL isReadonly = isReadonlyProperty(propertyAttributes);
-            
-            if (!isReadonly && [self respondsToSelector:NSSelectorFromString(propertyName)]) {
-                
-                // IBOutlet
-                if (NSClassFromString(propertyType) == [NSLayoutConstraint class]) {
-                    [self transferConstraintOutletForKey:propertyName
-                                                fromView:view];
-                }
-                // IBOutlet​Collection
-                if ([NSClassFromString(propertyType) isSubclassOfClass:[NSArray class]]) {
-                    [self transferConstraintOutletsForKey:propertyName
-                                                 fromView:view];
-                }
-                
-            }
-            
-        }
-        
-    }
-    
-    free(properties);
-}
-
-- (void)transferConstraintOutletForKey:(NSString *)propertyName
-                             fromView:(UIView *)view
-{
-    NSLayoutConstraint *constraint = [self valueForKey:propertyName];
-    if (constraint.typhoonTransferIdentifier) {
-        for (NSLayoutConstraint *transferConstraint in view.constraints) {
-            BOOL equalObjects = constraint == transferConstraint;
-            BOOL equalIdentifier = [constraint.typhoonTransferIdentifier isEqualToString:transferConstraint.typhoonTransferIdentifier];
-            if (!equalObjects && equalIdentifier) {
-                [self setValue:transferConstraint
-                        forKey:propertyName];
-            }
-        }
-    }
-}
-
-- (void)transferConstraintOutletsForKey:(NSString *)propertyName
-                             fromView:(UIView *)view
-{
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self isKindOfClass: %@",
-                              [NSLayoutConstraint class]];
-    NSArray *constraints = [self valueForKey:propertyName];
-    NSArray *filtered = [constraints filteredArrayUsingPredicate:predicate];
-    
-    if (filtered.count > 0) {
-        
-        BOOL needChange = NO;
-        NSMutableArray *newOutlets = [NSMutableArray new];
-        
-        for (id outlet in constraints) {
-            
-            id changeOutlet = outlet;
-
-            if ([outlet isMemberOfClass:[NSLayoutConstraint class]]) {
-        
-                NSLayoutConstraint *constraint = outlet;
-                
-                if (constraint.typhoonTransferIdentifier) {
-                    
-                    for (NSLayoutConstraint *transferConstraint in view.constraints) {
-                        
-                        BOOL equalObjects = constraint == transferConstraint;
-                        BOOL equalIdentifier = [constraint.typhoonTransferIdentifier isEqualToString:transferConstraint.typhoonTransferIdentifier];
-                        
-                        if (!equalObjects && equalIdentifier) {
-                            changeOutlet = transferConstraint;
-                            needChange = YES;
-                        }
-                        
-                    }
-                    
-                }
-            }
-            
-            [newOutlets addObject:changeOutlet];
-            
-        }
-        
-        if (needChange) {
-            [self setValue:newOutlets
-                    forKey:propertyName];
-        }
-        
-    }
-}
-
 - (UIView *)findRootView:(UIView *)view
 {
     NSArray *expulsionViewClasses = [self expulsionViewClasses];
     // Optimization. The outlet from view to the UICollectionViewCell is invalid.
     // Outlets cannot be connected to repeating content.
-    BOOL expulsion = NO;
     for (Class expulsionClass in expulsionViewClasses) {
         if ([view isKindOfClass:expulsionClass]) {
-            expulsion = YES;
+            return view;
         }
     }
+    
+    UIResponder *nextRexponder = [view nextResponder];
+    if ([nextRexponder isKindOfClass:[UIViewController class]]) {
+        return view;
+    }
 
-    if (view.superview && !expulsion) {
+    if (view.superview) {
         return [view.superview findRootView:view.superview];
     }
     return view;
@@ -212,30 +114,6 @@
 {
     return @[[UITableViewCell class],
              [UICollectionViewCell class]];
-}
-
-
-static const char *getPropertyType(const char * attributes)
-{
-    char buffer[1 + strlen(attributes)];
-    strlcpy(buffer, attributes, sizeof(buffer));
-    char *state = buffer, *attribute;
-    while ((attribute = strsep(&state, ",")) != NULL) {
-        if (attribute[0] == 'T') {
-            if (strlen(attribute) <= 4) {
-                break;
-            }
-            return (const char *)[[NSData dataWithBytes:(attribute + 3) length:strlen(attribute) - 4] bytes];
-        }
-    }
-    return "@";
-}
-
-static BOOL isReadonlyProperty(const char * propertyAttributes)
-{
-    NSArray *attributes = [[NSString stringWithUTF8String:propertyAttributes]
-                           componentsSeparatedByString:@","];
-    return [attributes containsObject:@"R"];
 }
 
 @end

--- a/Tests/iOS/Storyboard/LoadedView.h
+++ b/Tests/iOS/Storyboard/LoadedView.h
@@ -1,0 +1,17 @@
+//
+//  LoadedView.h
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LoadedView : UIView
+
+@property (strong, nonatomic) NSNumber *injectedValue;
+
++ (instancetype)loadFromNib;
+
+@end

--- a/Tests/iOS/Storyboard/LoadedView.h
+++ b/Tests/iOS/Storyboard/LoadedView.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  LoadedView.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <UIKit/UIKit.h>
 

--- a/Tests/iOS/Storyboard/LoadedView.m
+++ b/Tests/iOS/Storyboard/LoadedView.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  LoadedView.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "LoadedView.h"
 

--- a/Tests/iOS/Storyboard/LoadedView.m
+++ b/Tests/iOS/Storyboard/LoadedView.m
@@ -1,0 +1,20 @@
+//
+//  LoadedView.m
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import "LoadedView.h"
+
+@implementation LoadedView
+
++ (instancetype)loadFromNib
+{
+    return [[[NSBundle bundleForClass:self] loadNibNamed:NSStringFromClass([self class])
+                                                   owner:self
+                                                 options:NULL] firstObject];
+}
+
+@end

--- a/Tests/iOS/Storyboard/LoadedView.xib
+++ b/Tests/iOS/Storyboard/LoadedView.xib
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="LoadedView">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+        </view>
+    </objects>
+</document>

--- a/Tests/iOS/Storyboard/RootView.h
+++ b/Tests/iOS/Storyboard/RootView.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  RootView.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <UIKit/UIKit.h>
 

--- a/Tests/iOS/Storyboard/RootView.h
+++ b/Tests/iOS/Storyboard/RootView.h
@@ -1,0 +1,25 @@
+//
+//  RootView.h
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class LoadedView;
+
+@interface RootView : UIView
+
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *leadingConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *topConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *widthConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *heightConstraint;
+@property (strong, nonatomic) IBOutletCollection(NSLayoutConstraint) NSArray *outlets;
+
+
+@property (weak, nonatomic) IBOutlet LoadedView *loadedView;
+@property (weak, nonatomic) IBOutlet RootView *anotherView;
+
+@end

--- a/Tests/iOS/Storyboard/RootView.m
+++ b/Tests/iOS/Storyboard/RootView.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  RootView.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "RootView.h"
 

--- a/Tests/iOS/Storyboard/RootView.m
+++ b/Tests/iOS/Storyboard/RootView.m
@@ -1,0 +1,13 @@
+//
+//  RootView.m
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import "RootView.h"
+
+@implementation RootView
+
+@end

--- a/Tests/iOS/Storyboard/RootView.xib
+++ b/Tests/iOS/Storyboard/RootView.xib
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10117"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="RootView">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" restorationIdentifier="loadedView" translatesAutoresizingMaskIntoConstraints="NO" id="qtR-EY-xFN" customClass="TyphoonLoadedView">
+                    <rect key="frame" x="124" y="159" width="240" height="128"/>
+                    <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="240" id="HoI-3C-zYj"/>
+                        <constraint firstAttribute="height" constant="128" id="pW3-3B-cNg"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FB2-OV-oFQ" customClass="RootView">
+                    <rect key="frame" x="180" y="236" width="240" height="128"/>
+                    <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <connections>
+                        <outlet property="heightConstraint" destination="pW3-3B-cNg" id="EHG-Ae-zVB"/>
+                        <outlet property="leadingConstraint" destination="I8q-d1-qWV" id="bVT-LU-SPD"/>
+                        <outlet property="topConstraint" destination="K5q-hH-0ID" id="7bU-8Z-Elb"/>
+                        <outlet property="widthConstraint" destination="HoI-3C-zYj" id="tqo-ee-Grq"/>
+                        <outletCollection property="outlets" destination="HoI-3C-zYj" id="sfS-Gb-9VA"/>
+                        <outletCollection property="outlets" destination="pW3-3B-cNg" id="cAG-Sv-OYo"/>
+                    </connections>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="FB2-OV-oFQ" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="CaF-Gu-JcX"/>
+                <constraint firstItem="FB2-OV-oFQ" firstAttribute="width" secondItem="qtR-EY-xFN" secondAttribute="width" id="E9h-Hq-5JX"/>
+                <constraint firstItem="qtR-EY-xFN" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="124" id="I8q-d1-qWV"/>
+                <constraint firstItem="qtR-EY-xFN" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="159" id="K5q-hH-0ID"/>
+                <constraint firstItem="FB2-OV-oFQ" firstAttribute="height" secondItem="qtR-EY-xFN" secondAttribute="height" id="TzA-9H-20E"/>
+                <constraint firstItem="FB2-OV-oFQ" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="b1j-ae-q28"/>
+            </constraints>
+            <connections>
+                <outlet property="anotherView" destination="FB2-OV-oFQ" id="Wae-Bq-2E6"/>
+                <outlet property="heightConstraint" destination="pW3-3B-cNg" id="NV8-HY-23d"/>
+                <outlet property="leadingConstraint" destination="I8q-d1-qWV" id="1p9-OK-QRP"/>
+                <outlet property="loadedView" destination="qtR-EY-xFN" id="fRQ-M4-Glt"/>
+                <outlet property="topConstraint" destination="K5q-hH-0ID" id="kYi-w1-t8h"/>
+                <outlet property="widthConstraint" destination="HoI-3C-zYj" id="gRy-X8-4oZ"/>
+                <outletCollection property="outlets" destination="HoI-3C-zYj" id="aSf-aE-yTU"/>
+                <outletCollection property="outlets" destination="pW3-3B-cNg" id="mZl-qA-mUn"/>
+            </connections>
+        </view>
+    </objects>
+</document>

--- a/Tests/iOS/Storyboard/RootViewAssembly.h
+++ b/Tests/iOS/Storyboard/RootViewAssembly.h
@@ -1,0 +1,15 @@
+//
+//  RootViewAssembly.h
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import <Typhoon/Typhoon.h>
+
+@interface RootViewAssembly : TyphoonAssembly
+
+- (UIView *)loadedView;
+
+@end

--- a/Tests/iOS/Storyboard/RootViewAssembly.h
+++ b/Tests/iOS/Storyboard/RootViewAssembly.h
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  RootViewAssembly.h
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <Typhoon/Typhoon.h>
 

--- a/Tests/iOS/Storyboard/RootViewAssembly.m
+++ b/Tests/iOS/Storyboard/RootViewAssembly.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  RootViewAssembly.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import "RootViewAssembly.h"
 #import "LoadedView.h"

--- a/Tests/iOS/Storyboard/RootViewAssembly.m
+++ b/Tests/iOS/Storyboard/RootViewAssembly.m
@@ -1,0 +1,25 @@
+//
+//  RootViewAssembly.m
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import "RootViewAssembly.h"
+#import "LoadedView.h"
+#import <UIKit/UIKit.h>
+
+@implementation RootViewAssembly
+
+- (UIView *)loadedView
+{
+    return [TyphoonDefinition withClass:[LoadedView class]
+                          configuration:^(TyphoonDefinition *definition) {
+                              [definition useInitializer:@selector(loadFromNib)];
+                              [definition injectProperty:@selector(injectedValue)
+                                                    with:@(1)];
+                          }];
+}
+
+@end

--- a/Tests/iOS/Storyboard/TyphoonLoadedViewTransferOutletTests.m
+++ b/Tests/iOS/Storyboard/TyphoonLoadedViewTransferOutletTests.m
@@ -38,10 +38,9 @@
 - (void)test_transfer_constraints
 {
     // given
-    UIWindow *window = [UIWindow new];
-    RootView *rootView = [self loadView];
+   
     // when
-    [window addSubview:rootView];
+    RootView *rootView = [self loadView];
     // then
     XCTAssertEqualObjects(rootView.loadedView, rootView.subviews[0]);
     [self checkViewSuccessInjected:rootView.loadedView];
@@ -54,9 +53,7 @@
 - (void)test_change_transfered_constraints
 {
     // given
-    UIWindow *window = [UIWindow new];
     RootView *rootView = [self loadView];
-    [window addSubview:rootView];
     rootView.widthConstraint.constant = 10;
     rootView.heightConstraint.constant = 10;
     // when

--- a/Tests/iOS/Storyboard/TyphoonLoadedViewTransferOutletTests.m
+++ b/Tests/iOS/Storyboard/TyphoonLoadedViewTransferOutletTests.m
@@ -1,0 +1,100 @@
+//
+//  TyphoonLoadedViewTransferOutletTests.m
+//  Typhoon
+//
+//  Created by Smal Vadim on 01/08/16.
+//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "TyphoonLoadedView.h"
+#import "RootView.h"
+#import "LoadedView.h"
+#import "RootViewAssembly.h"
+#import "TyphoonComponentFactory.h"
+
+@interface TyphoonLoadedViewTransferOutletTests : XCTestCase
+
+@property (nonatomic, strong) RootViewAssembly *assembly;
+
+@end
+
+@implementation TyphoonLoadedViewTransferOutletTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.assembly = [RootViewAssembly new];
+    [self.assembly activate];
+    [TyphoonComponentFactory setFactoryForResolvingUI:(id)self.assembly];
+}
+
+- (void)tearDown
+{
+    self.assembly = nil;
+    [super tearDown];
+}
+
+- (void)test_transfer_constraints
+{
+    // given
+    UIWindow *window = [UIWindow new];
+    RootView *rootView = [self loadView];
+    // when
+    [window addSubview:rootView];
+    // then
+    XCTAssertEqualObjects(rootView.loadedView, rootView.subviews[0]);
+    [self checkViewSuccessInjected:rootView.loadedView];
+    [self checkConstraintsInView:rootView
+                      loadedView:rootView.loadedView];
+    [self checkConstraintsInView:rootView.anotherView
+                      loadedView:rootView.loadedView];
+}
+
+- (void)test_change_transfered_constraints
+{
+    // given
+    UIWindow *window = [UIWindow new];
+    RootView *rootView = [self loadView];
+    [window addSubview:rootView];
+    rootView.widthConstraint.constant = 10;
+    rootView.heightConstraint.constant = 10;
+    // when
+    [rootView setNeedsUpdateConstraints];
+    [rootView updateConstraintsIfNeeded];
+    [rootView setNeedsLayout];
+    [rootView layoutIfNeeded];
+    // then
+    XCTAssertEqual(rootView.loadedView.frame.size.width, rootView.widthConstraint.constant);
+    XCTAssertEqual(rootView.loadedView.frame.size.height, rootView.widthConstraint.constant);
+    XCTAssertEqual(rootView.anotherView.frame.size.width, rootView.widthConstraint.constant);
+    XCTAssertEqual(rootView.anotherView.frame.size.height, rootView.widthConstraint.constant);
+}
+
+- (RootView *)loadView
+{
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    return [[bundle loadNibNamed:NSStringFromClass([RootView class])
+                           owner:self
+                         options:NULL] firstObject];
+}
+
+- (void)checkViewSuccessInjected:(LoadedView *)loadedView
+{
+    XCTAssertEqualObjects(loadedView.backgroundColor, [UIColor greenColor]);
+    XCTAssertEqualObjects([loadedView class], [LoadedView class]);
+    XCTAssertNotNil(loadedView.injectedValue);
+}
+
+- (void)checkConstraintsInView:(RootView *)view
+                    loadedView:(UIView *)loadedView
+{
+    XCTAssertEqualObjects(view.widthConstraint, loadedView.constraints[0]);
+    XCTAssertEqualObjects(view.heightConstraint, loadedView.constraints[1]);
+    XCTAssertEqualObjects(view.leadingConstraint.firstItem, loadedView);
+    XCTAssertEqualObjects(view.topConstraint.firstItem, loadedView);
+    XCTAssertTrue([view.outlets containsObject:loadedView.constraints[0]]);
+    XCTAssertTrue([view.outlets containsObject:loadedView.constraints[1]]);
+}
+
+@end

--- a/Tests/iOS/Storyboard/TyphoonLoadedViewTransferOutletTests.m
+++ b/Tests/iOS/Storyboard/TyphoonLoadedViewTransferOutletTests.m
@@ -1,10 +1,13 @@
+////////////////////////////////////////////////////////////////////////////////
 //
-//  TyphoonLoadedViewTransferOutletTests.m
-//  Typhoon
+//  TYPHOON FRAMEWORK
+//  Copyright 2016, Typhoon Framework Contributors
+//  All Rights Reserved.
 //
-//  Created by Smal Vadim on 01/08/16.
-//  Copyright © 2016 typhoonframework.org. All rights reserved.
+//  NOTICE: The authors permit you to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //
+////////////////////////////////////////////////////////////////////////////////
 
 #import <XCTest/XCTest.h>
 #import "TyphoonLoadedView.h"

--- a/Tests/iOS/Storyboard/TyphoonViewHelpersTests.m
+++ b/Tests/iOS/Storyboard/TyphoonViewHelpersTests.m
@@ -12,6 +12,7 @@
 #import "TyphoonViewHelpers.h"
 #import "TyphoonAssembly.h"
 #import "TyphoonBlockComponentFactory.h"
+#import "NSLayoutConstraint+TyphoonOutletTransfer.h"
 
 @interface TyphoonViewHelpersFactory : TyphoonAssembly
 
@@ -38,7 +39,8 @@ BOOL equalProperties(NSLayoutConstraint *c1, NSLayoutConstraint *c2){
     c1.relation == c2.relation &&
     c1.firstAttribute == c2.firstAttribute &&
     c1.secondAttribute == c2.secondAttribute &&
-    c1.constant == c2.constant;
+    c1.constant == c2.constant &&
+    [c1.typhoonTransferIdentifier isEqualToString:c2.typhoonTransferIdentifier];
 }
 
 @interface TyphoonViewHelpersTests : XCTestCase
@@ -156,10 +158,10 @@ BOOL equalProperties(NSLayoutConstraint *c1, NSLayoutConstraint *c2){
     
     for (NSLayoutConstraint *dstConstraint in dst.constraints) {
         BOOL didFindEqualPointer = NO;
+        BOOL notRetainSourceConstraint = NO;
         
         for (NSLayoutConstraint *srcConstraint in src.constraints) {
             if (equalProperties(dstConstraint, srcConstraint)){
-                
                 BOOL replaceFirstItem = [srcConstraint firstItem] == src;
                 BOOL replaceSecondItem = [srcConstraint secondItem] == src;
                 id firstItem = replaceFirstItem ? dst : srcConstraint.firstItem;
@@ -168,12 +170,17 @@ BOOL equalProperties(NSLayoutConstraint *c1, NSLayoutConstraint *c2){
                 if ([dstConstraint.firstItem isEqual:firstItem] &&
                     [dstConstraint.secondItem isEqual:secondItem]) {
                     didFindEqualPointer = YES;
-                    break;
                 }
+                
+                if (dstConstraint.typhoonTransferConstraint != srcConstraint) {
+                    notRetainSourceConstraint = YES;
+                }
+                
             }
         }
         
         XCTAssertTrue(didFindEqualPointer, @"%@", dstConstraint.description);
+        XCTAssertFalse(notRetainSourceConstraint, @"%@", dstConstraint.description);
     }
     
     XCTAssertEqual(dst.constraints.count, src.constraints.count);

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -941,10 +941,11 @@
 		DD38B1EE1D4FA3E000B62029 /* TyphoonViewHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8946F2DC1B8E3F44005C4954 /* TyphoonViewHelpersTests.m */; };
 		DD38B1F01D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1EF1D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m */; };
 		DD38B1F31D4FA82B00B62029 /* RootView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1F21D4FA82B00B62029 /* RootView.m */; };
-		DD38B1F51D4FA95C00B62029 /* RootView.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD38B1F41D4FA95C00B62029 /* RootView.xib */; };
 		DD38B1F81D4FAB3A00B62029 /* RootViewAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1F71D4FAB3A00B62029 /* RootViewAssembly.m */; };
 		DD38B1FB1D4FABF900B62029 /* LoadedView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1FA1D4FABF900B62029 /* LoadedView.m */; };
-		DD38B1FD1D4FAC1200B62029 /* LoadedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */; };
+		DDB5C2631D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.m in Sources */ = {isa = PBXBuildFile; fileRef = DDB5C2621D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.m */; };
+		DDB5C26F1D51EBA400C8B9EE /* LoadedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */; };
+		DDB5C2721D51ECF400C8B9EE /* RootView.xib in Resources */ = {isa = PBXBuildFile; fileRef = DDB5C2701D51ECEA00C8B9EE /* RootView.xib */; };
 		FAF2E92219C2260F00211DF6 /* TyphoonInjectedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1899426943444774AC27 /* TyphoonInjectedObject.m */; };
 /* End PBXBuildFile section */
 
@@ -1526,12 +1527,14 @@
 		DD38B1EF1D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLoadedViewTransferOutletTests.m; sourceTree = "<group>"; };
 		DD38B1F11D4FA82B00B62029 /* RootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootView.h; sourceTree = "<group>"; };
 		DD38B1F21D4FA82B00B62029 /* RootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootView.m; sourceTree = "<group>"; };
-		DD38B1F41D4FA95C00B62029 /* RootView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RootView.xib; sourceTree = "<group>"; };
 		DD38B1F61D4FAB3A00B62029 /* RootViewAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootViewAssembly.h; sourceTree = "<group>"; };
 		DD38B1F71D4FAB3A00B62029 /* RootViewAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootViewAssembly.m; sourceTree = "<group>"; };
 		DD38B1F91D4FABF900B62029 /* LoadedView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadedView.h; sourceTree = "<group>"; };
 		DD38B1FA1D4FABF900B62029 /* LoadedView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoadedView.m; sourceTree = "<group>"; };
 		DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LoadedView.xib; sourceTree = "<group>"; };
+		DDB5C2611D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIResponder+TyphoonOutletTransfer.h"; sourceTree = "<group>"; };
+		DDB5C2621D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIResponder+TyphoonOutletTransfer.m"; sourceTree = "<group>"; };
+		DDB5C2701D51ECEA00C8B9EE /* RootView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RootView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2048,6 +2051,8 @@
 		6B076F511936F63A0083714E /* Storyboard */ = {
 			isa = PBXGroup;
 			children = (
+				DDB5C2611D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.h */,
+				DDB5C2621D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.m */,
 				DD38B1E61D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.h */,
 				DD38B1E71D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.m */,
 				DD38B1E31D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.h */,
@@ -2846,9 +2851,9 @@
 				DD38B1EF1D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m */,
 				DD38B1F11D4FA82B00B62029 /* RootView.h */,
 				DD38B1F21D4FA82B00B62029 /* RootView.m */,
+				DDB5C2701D51ECEA00C8B9EE /* RootView.xib */,
 				DD38B1F91D4FABF900B62029 /* LoadedView.h */,
 				DD38B1FA1D4FABF900B62029 /* LoadedView.m */,
-				DD38B1F41D4FA95C00B62029 /* RootView.xib */,
 				DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */,
 				74AD3FFA0A4C1A06C176CF4E /* StoryboardWithReference */,
 			);
@@ -3408,14 +3413,14 @@
 			files = (
 				6B07727819370A920083714E /* SomeResource in Resources */,
 				B79797D21D0AE4C80006ADEE /* StoryboardWithReference.storyboard in Resources */,
-				DD38B1FD1D4FAC1200B62029 /* LoadedView.xib in Resources */,
+				DDB5C2721D51ECF400C8B9EE /* RootView.xib in Resources */,
 				9F26AA711BF9BBF800663188 /* PropertiesA.plist in Resources */,
+				DDB5C26F1D51EBA400C8B9EE /* LoadedView.xib in Resources */,
 				6B07726C19370A870083714E /* SomeProperties.json in Resources */,
 				6B07727419370A8F0083714E /* SomeProperties.properties in Resources */,
 				6B07727019370A8B0083714E /* SomeProperties.plist in Resources */,
 				6B07726819370A830083714E /* SomeOtherProperties.properties in Resources */,
 				9F26AA741BF9BBFB00663188 /* PropertiesB.plist in Resources */,
-				DD38B1F51D4FA95C00B62029 /* RootView.xib in Resources */,
 				6B077463193786EC0083714E /* Storyboard.storyboard in Resources */,
 				BA7983F3CBA8963020F0AD62 /* development_Config.plist in Resources */,
 				B7842F881D0AEF36003FD8FA /* Second.storyboard in Resources */,
@@ -3547,6 +3552,7 @@
 				6B0770AF1936F9000083714E /* Collections+CustomInjection.m in Sources */,
 				6B0770B01936F9000083714E /* NSDictionary+CustomInjection.m in Sources */,
 				6B0770B21936F9000083714E /* TyphoonDefinition+InstanceBuilder.m in Sources */,
+				DDB5C2631D51DFF900C8B9EE /* UIResponder+TyphoonOutletTransfer.m in Sources */,
 				6B0770B31936F9000083714E /* TyphoonReferenceDefinition.m in Sources */,
 				6B0770B41936F9000083714E /* TyphoonMethod+InstanceBuilder.m in Sources */,
 				6B0770B51936F9000083714E /* TyphoonMethod.m in Sources */,

--- a/Typhoon.xcodeproj/project.pbxproj
+++ b/Typhoon.xcodeproj/project.pbxproj
@@ -936,6 +936,15 @@
 		BB7F98241CA6F1FD003B3E1F /* Typhoon+Infrastructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 01A28DBF1C5D2636006F0A95 /* Typhoon+Infrastructure.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C9497A0F3C744433419C9D5D /* TyphoonInjectionByCurrentRuntimeArguments.m in Sources */ = {isa = PBXBuildFile; fileRef = C94972BE857448DEBA12C1CE /* TyphoonInjectionByCurrentRuntimeArguments.m */; };
 		C9497BE0FC290233160074AC /* Mock.m in Sources */ = {isa = PBXBuildFile; fileRef = C949792A85FC9383BEAD631B /* Mock.m */; };
+		DD38B1E51D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1E41D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.m */; };
+		DD38B1E81D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1E71D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.m */; };
+		DD38B1EE1D4FA3E000B62029 /* TyphoonViewHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8946F2DC1B8E3F44005C4954 /* TyphoonViewHelpersTests.m */; };
+		DD38B1F01D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1EF1D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m */; };
+		DD38B1F31D4FA82B00B62029 /* RootView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1F21D4FA82B00B62029 /* RootView.m */; };
+		DD38B1F51D4FA95C00B62029 /* RootView.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD38B1F41D4FA95C00B62029 /* RootView.xib */; };
+		DD38B1F81D4FAB3A00B62029 /* RootViewAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1F71D4FAB3A00B62029 /* RootViewAssembly.m */; };
+		DD38B1FB1D4FABF900B62029 /* LoadedView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD38B1FA1D4FABF900B62029 /* LoadedView.m */; };
+		DD38B1FD1D4FAC1200B62029 /* LoadedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */; };
 		FAF2E92219C2260F00211DF6 /* TyphoonInjectedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA1899426943444774AC27 /* TyphoonInjectedObject.m */; };
 /* End PBXBuildFile section */
 
@@ -1510,6 +1519,19 @@
 		C949758EA994B0137DD95E6D /* Mock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mock.h; sourceTree = "<group>"; };
 		C949766E39C445A43A7517B8 /* TyphoonInjectionByCurrentRuntimeArguments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TyphoonInjectionByCurrentRuntimeArguments.h; sourceTree = "<group>"; };
 		C949792A85FC9383BEAD631B /* Mock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Mock.m; sourceTree = "<group>"; };
+		DD38B1E31D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSLayoutConstraint+TyphoonOutletTransfer.h"; sourceTree = "<group>"; };
+		DD38B1E41D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLayoutConstraint+TyphoonOutletTransfer.m"; sourceTree = "<group>"; };
+		DD38B1E61D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+TyphoonOutletTransfer.h"; sourceTree = "<group>"; };
+		DD38B1E71D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+TyphoonOutletTransfer.m"; sourceTree = "<group>"; };
+		DD38B1EF1D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TyphoonLoadedViewTransferOutletTests.m; sourceTree = "<group>"; };
+		DD38B1F11D4FA82B00B62029 /* RootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootView.h; sourceTree = "<group>"; };
+		DD38B1F21D4FA82B00B62029 /* RootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootView.m; sourceTree = "<group>"; };
+		DD38B1F41D4FA95C00B62029 /* RootView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RootView.xib; sourceTree = "<group>"; };
+		DD38B1F61D4FAB3A00B62029 /* RootViewAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootViewAssembly.h; sourceTree = "<group>"; };
+		DD38B1F71D4FAB3A00B62029 /* RootViewAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootViewAssembly.m; sourceTree = "<group>"; };
+		DD38B1F91D4FABF900B62029 /* LoadedView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadedView.h; sourceTree = "<group>"; };
+		DD38B1FA1D4FABF900B62029 /* LoadedView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoadedView.m; sourceTree = "<group>"; };
+		DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LoadedView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2026,6 +2048,10 @@
 		6B076F511936F63A0083714E /* Storyboard */ = {
 			isa = PBXGroup;
 			children = (
+				DD38B1E61D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.h */,
+				DD38B1E71D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.m */,
+				DD38B1E31D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.h */,
+				DD38B1E41D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.m */,
 				6B076F521936F63A0083714E /* TyphoonStoryboard.h */,
 				6B076F531936F63A0083714E /* TyphoonStoryboard.m */,
 				2DBA1F19AACBE84474E823C4 /* TyphoonStoryboardResolver.m */,
@@ -2815,6 +2841,15 @@
 				BA7983C7D0A3DFE423250300 /* StoryboardControllerDependency.m */,
 				BA798969F71AF5247112BEE9 /* StoryboardControllerDependency.h */,
 				8946F2DC1B8E3F44005C4954 /* TyphoonViewHelpersTests.m */,
+				DD38B1F61D4FAB3A00B62029 /* RootViewAssembly.h */,
+				DD38B1F71D4FAB3A00B62029 /* RootViewAssembly.m */,
+				DD38B1EF1D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m */,
+				DD38B1F11D4FA82B00B62029 /* RootView.h */,
+				DD38B1F21D4FA82B00B62029 /* RootView.m */,
+				DD38B1F91D4FABF900B62029 /* LoadedView.h */,
+				DD38B1FA1D4FABF900B62029 /* LoadedView.m */,
+				DD38B1F41D4FA95C00B62029 /* RootView.xib */,
+				DD38B1FC1D4FAC1200B62029 /* LoadedView.xib */,
 				74AD3FFA0A4C1A06C176CF4E /* StoryboardWithReference */,
 			);
 			path = Storyboard;
@@ -3373,12 +3408,14 @@
 			files = (
 				6B07727819370A920083714E /* SomeResource in Resources */,
 				B79797D21D0AE4C80006ADEE /* StoryboardWithReference.storyboard in Resources */,
+				DD38B1FD1D4FAC1200B62029 /* LoadedView.xib in Resources */,
 				9F26AA711BF9BBF800663188 /* PropertiesA.plist in Resources */,
 				6B07726C19370A870083714E /* SomeProperties.json in Resources */,
 				6B07727419370A8F0083714E /* SomeProperties.properties in Resources */,
 				6B07727019370A8B0083714E /* SomeProperties.plist in Resources */,
 				6B07726819370A830083714E /* SomeOtherProperties.properties in Resources */,
 				9F26AA741BF9BBFB00663188 /* PropertiesB.plist in Resources */,
+				DD38B1F51D4FA95C00B62029 /* RootView.xib in Resources */,
 				6B077463193786EC0083714E /* Storyboard.storyboard in Resources */,
 				BA7983F3CBA8963020F0AD62 /* development_Config.plist in Resources */,
 				B7842F881D0AEF36003FD8FA /* Second.storyboard in Resources */,
@@ -3519,6 +3556,7 @@
 				6B0770C21936F9000083714E /* NSInvocation+TCFInstanceBuilder.m in Sources */,
 				6B0770C31936F9000083714E /* NSInvocation+TCFUnwrapValues.m in Sources */,
 				6B0770C41936F9000083714E /* NSMethodSignature+TCFUnwrapValues.m in Sources */,
+				DD38B1E81D4F86CC00B62029 /* UIView+TyphoonOutletTransfer.m in Sources */,
 				6B0770C51936F9000083714E /* NSValue+TCFUnwrapValues.m in Sources */,
 				6B0770C61936F9000083714E /* TyphoonCallStack.m in Sources */,
 				6B0770C71936F9000083714E /* TyphoonComponentFactory+InstanceBuilder.m in Sources */,
@@ -3557,6 +3595,7 @@
 				BA7983F8D0DDDE5371B74C24 /* TyphoonCollaboratingAssemblyPropertyEnumerator.m in Sources */,
 				0183B7621C827DE100644B62 /* TyphoonInject.m in Sources */,
 				BA7980CD12EE7634604F50AB /* TyphoonRuntimeArguments.m in Sources */,
+				DD38B1E51D4F86BF00B62029 /* NSLayoutConstraint+TyphoonOutletTransfer.m in Sources */,
 				BA79843184EDDDC88CA798AE /* TyphoonAssemblySelectorAdviser.m in Sources */,
 				BA7988EFB2373212F66191F7 /* TyphoonCollaboratingAssemblyProxy.m in Sources */,
 				01A28DE91C5D63FE006F0A95 /* TyphoonBlockDefinition+InstanceBuilder.m in Sources */,
@@ -3591,6 +3630,7 @@
 				6B0770FC1936FEA80083714E /* TyphoonMethodInjectionsTests.m in Sources */,
 				6B0770FD1936FEA80083714E /* ComponentFactoryAwareAssembly.m in Sources */,
 				6B0770FE1936FEA80083714E /* ComponentFactoryAwareObject.m in Sources */,
+				DD38B1FB1D4FABF900B62029 /* LoadedView.m in Sources */,
 				6B0770FF1936FEA80083714E /* TyphoonComponentFactoryAwareTests.m in Sources */,
 				6B0771001936FEA80083714E /* ClassWithCollectionProperties.m in Sources */,
 				6B0771011936FEA80083714E /* TyphoonPropertyInjectedAsCollectionTests.m in Sources */,
@@ -3625,20 +3665,24 @@
 				6B0771361936FEA80083714E /* TyphoonWeakComponentsPoolTests.m in Sources */,
 				6B43ED5C1A8FA8870071EFC7 /* SwiftMiddleAgesAssembly.swift in Sources */,
 				6B0771371936FEA80083714E /* main.m in Sources */,
+				DD38B1F01D4FA66900B62029 /* TyphoonLoadedViewTransferOutletTests.m in Sources */,
 				6B0771381936FEA80083714E /* TyphooniOSAppDelegate.m in Sources */,
 				6B0771391936FEA80083714E /* TyphoonViewController.m in Sources */,
 				6B07713C1936FEA80083714E /* CampaignQuest.m in Sources */,
 				6B07713D1936FEA80083714E /* CavalryMan.m in Sources */,
 				6B07713E1936FEA80083714E /* Champion.m in Sources */,
+				DD38B1F31D4FA82B00B62029 /* RootView.m in Sources */,
 				9F5E6FAC1BA15073000356A0 /* TyphoonCollaboratingAssembliesCollectorTests.m in Sources */,
 				6B07713F1936FEA80083714E /* ClassADependsOnB.m in Sources */,
 				6B0771401936FEA80083714E /* ClassBDependsOnA.m in Sources */,
 				6B0771411936FEA80083714E /* ClassCDependsOnDAndE.m in Sources */,
+				DD38B1EE1D4FA3E000B62029 /* TyphoonViewHelpersTests.m in Sources */,
 				6B0771421936FEA80083714E /* ClassDDependsOnC.m in Sources */,
 				6B0771431936FEA80083714E /* ClassEDependsOnC.m in Sources */,
 				6B0771441936FEA80083714E /* PrototypeInitInjected.m in Sources */,
 				6B0771451936FEA80083714E /* PrototypePropertyInjected.m in Sources */,
 				6B0771461936FEA80083714E /* UnsatisfiableClassFDependsOnGInInitializer.m in Sources */,
+				DD38B1F81D4FAB3A00B62029 /* RootViewAssembly.m in Sources */,
 				6B0771471936FEA80083714E /* UnsatisfiableClassGDependsOnFInInitializer.m in Sources */,
 				6B0771481936FEA80083714E /* CROPrototypeA.m in Sources */,
 				6B0771491936FEA80083714E /* CROPrototypeB.m in Sources */,

--- a/Typhoon.xcodeproj/xcshareddata/xcschemes/Typhoon.xcscheme
+++ b/Typhoon.xcodeproj/xcshareddata/xcschemes/Typhoon.xcscheme
@@ -36,10 +36,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -61,15 +61,18 @@
             ReferencedContainer = "container:Typhoon.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -84,10 +87,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
Solution with a subclass does not work ( in the ios 10 no more ivar firstItem, secondItem). 
In the pull request, I implemented another more complicated solution. It works correctly on all operating system versions. I also added integration tests on the transfer of outlets. I hope you are satisfied with this solution, unfortunately more elegant and working solution could not be found. Even with the use swizzle (these solutions also tried).