### PR TITLE
Fix 'attach' method declarations that are ambiguous in Swift 3

### DIFF
--- a/Source/Factory/TyphoonComponentFactory.h
+++ b/Source/Factory/TyphoonComponentFactory.h
@@ -85,13 +85,13 @@
 Attach a TyphoonDefinitionPostProcessor to this component factory.
 @param postProcessor The definition post processor to attach.
 */
-- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor;
+- (void)attachDefinitionPostProcessor:(id<TyphoonDefinitionPostProcessor>)postProcessor NS_SWIFT_NAME(attachDefinitionPostProcessor(postProcessor:));
 
 /**
  Attach a TyphoonInstancePostProcessor to this component factory.
  @param postProcessor The instance post processor to attach.
  */
-- (void)attachInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor;
+- (void)attachInstancePostProcessor:(id<TyphoonInstancePostProcessor>)postProcessor NS_SWIFT_NAME(attachInstancePostProcessor(postProcessor:));
 
 /**
  Attach a TyphoonTypeConverter to this component factory.


### PR DESCRIPTION
`TyphoonComponentFactory.attachDefinitionPostProcessor` and `TyphoonComponentFactory.attachInstancePostProcessor` both resolve to `TyphoonComponentFactory.attach` with Swift's automatic method name generation.

This causes a compilation error with Swift 3 (maybe even earlier versions; all I know is that I wasn't encountering this in Swift 1.x): `myAssembly.attach(myPatcher)` would fail saying that method `attach` is ambiguous. Unfortunately, there doesn't seem to be a workaround, so I resorted to `NS_SWIFT_NAME` to explicitly set the Swift method names.