### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ let viewControler = assembly.recommendationController() as! RecommendationContro
 
 Typhoon is available through <a href="http://cocoapods.org/?q=Typhoon">CocoaPods</a> or <a href="https://github.com/Carthage/Carthage">Carthage</a>, and also builds easily from source.
 
-##With CocoaPods . . . 
+## With CocoaPods . . . 
 
-###Static Library
+### Static Library
 
 ```ruby
 
@@ -57,7 +57,7 @@ pod 'Typhoon'
 end
 ```
 
-###Dynamic Framework
+### Dynamic Framework
 
 If you're using Swift, you may wish to install dynamic frameworks, which can be done with the Podfile shown below: 
 
@@ -78,13 +78,13 @@ Simply import the Typhoon module in any Swift file that uses the framework:
 import Typhoon
 ```
 
-##With Carthage
+## With Carthage
 
 ```
 github "appsquickly/Typhoon"
 ```
 
-##From Source
+## From Source
 
 Alternatively, add the source files to your project's target or set up an Xcode workspace. 
 

--- a/Source/Vendor/OCLogTemplate/README.md
+++ b/Source/Vendor/OCLogTemplate/README.md
@@ -1,13 +1,13 @@
 A super-lightweight logging framework for Objective-C projects. Based on Brenwill workshop's Flexible iOS Logging Framework: http://brenwill.com/2010/flexible-ios-logging/ 
 
-#FEATURES
+# FEATURES
 
 * Just one file - use as an alternative to NSLog
 * Supports multiple log levels - Debug, Info, Warning, Error, Trace
 * Performance: Logging can be compiled in our out of code with one flag. 
 * Supports multiple formats - line numbers, file, etc. 
 
-#INSTALLING
+# INSTALLING
 
 Just include `OCLogTemplate.h` in your project. 
 
@@ -17,13 +17,13 @@ Can be installed via CocoaPods too, for use as a transitive dependency in librar
 pod 'OCLogTemplate'
 ```
 
-#USAGE
+# USAGE
 
 ```objc
 LogDebug(@"Message: %@", formatArg);
 ```
 
-#FULLY FLEDGED LOGGING TOOLS
+# FULLY FLEDGED LOGGING TOOLS
 
 * <a href="https://github.com/CocoaLumberjack/CocoaLumberjack">CoocaLumberjack</a>
 * <a href="https://github.com/fpillet/NSLogger">NSLogger</a>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
