### PR TITLE
Always calls setDelegate: original implementation.

### DIFF
--- a/Source/Configuration/Startup/TyphoonStartup.m
+++ b/Source/Configuration/Startup/TyphoonStartup.m
@@ -98,6 +98,7 @@ static id initialAppDelegate = nil;
     
     IMP adjustedImp = imp_implementationWithBlock(^(id instance, id delegate) {
         if (!delegate || initialAppDelegate) {
+            originalImp(instance, sel, delegate);
             return;
         }
         //This ensures that Typhoon startup runs only once


### PR DESCRIPTION
This fixes an issue that setting application delegate with nil or for the second time has no effect.