### PR TITLE
Fixed "This block declaration is not a prototype" warnings.

### DIFF
--- a/Source/Definition/Internal/TyphoonBlockDefinitionController.h
+++ b/Source/Definition/Internal/TyphoonBlockDefinitionController.h
@@ -36,15 +36,15 @@ typedef NS_ENUM(NSInteger, TyphoonBlockDefinitionRoute) {
 
 @property (nonatomic, strong, readonly) TyphoonInjectionContext *injectionContext;
 
-- (void)useConfigurationRouteWithinBlock:(void (^)())block;
+- (void)useConfigurationRouteWithinBlock:(void (^)(void))block;
 
 - (void)useInitializerRouteWithDefinition:(TyphoonBlockDefinition *)definition
                          injectionContext:(TyphoonInjectionContext *)context
-                              withinBlock:(void (^)())block;
+                              withinBlock:(void (^)(void))block;
 
 - (void)useInjectionsRouteWithDefinition:(TyphoonBlockDefinition *)definition
                                 instance:(id)instance
                         injectionContext:(TyphoonInjectionContext *)context
-                             withinBlock:(void (^)())block;
+                             withinBlock:(void (^)(void))block;
 
 @end

--- a/Source/Definition/Internal/TyphoonBlockDefinitionController.m
+++ b/Source/Definition/Internal/TyphoonBlockDefinitionController.m
@@ -35,14 +35,14 @@ static NSString * const kThreadDictionaryKey = @"org.typhoonframework.blockDefin
     return _route == TyphoonBlockDefinitionRouteInitializer || _route == TyphoonBlockDefinitionRouteInjections;
 }
 
-- (void)useConfigurationRouteWithinBlock:(void (^)())block
+- (void)useConfigurationRouteWithinBlock:(void (^)(void))block
 {
     [self useRoute:TyphoonBlockDefinitionRouteConfiguration withinBlock:block];
 }
 
 - (void)useInitializerRouteWithDefinition:(TyphoonBlockDefinition *)definition
                          injectionContext:(TyphoonInjectionContext *)context
-                              withinBlock:(void (^)())block
+                              withinBlock:(void (^)(void))block
 {
     _definition = definition;
     _injectionContext = context;
@@ -53,7 +53,7 @@ static NSString * const kThreadDictionaryKey = @"org.typhoonframework.blockDefin
 - (void)useInjectionsRouteWithDefinition:(TyphoonBlockDefinition *)definition
                                 instance:(id)instance
                         injectionContext:(TyphoonInjectionContext *)context
-                             withinBlock:(void (^)())block
+                             withinBlock:(void (^)(void))block
 {
     _definition = definition;
     _instance = instance;
@@ -64,7 +64,7 @@ static NSString * const kThreadDictionaryKey = @"org.typhoonframework.blockDefin
 
 #pragma mark - Private Methods
 
-- (void)useRoute:(TyphoonBlockDefinitionRoute)route withinBlock:(void (^)())block
+- (void)useRoute:(TyphoonBlockDefinitionRoute)route withinBlock:(void (^)(void))block
 {
     _route = route;
     

--- a/Source/Definition/TyphoonBlockDefinition.h
+++ b/Source/Definition/TyphoonBlockDefinition.h
@@ -12,7 +12,7 @@
 
 #import "TyphoonDefinition.h"
 
-typedef id (^TyphoonBlockDefinitionInitializerBlock)();
+typedef id (^TyphoonBlockDefinitionInitializerBlock)(void);
 
 typedef void (^TyphoonBlockDefinitionInjectionsBlock)(id instance);
 

--- a/Source/Factory/Internal/TyphoonCallStack.h
+++ b/Source/Factory/Internal/TyphoonCallStack.h
@@ -28,6 +28,6 @@
 
 - (BOOL)isEmpty;
 
-- (void)notifyOnceWhenStackEmptyUsingBlock:(void(^)())onEmpty;
+- (void)notifyOnceWhenStackEmptyUsingBlock:(void(^)(void))onEmpty;
 
 @end

--- a/Source/Factory/Internal/TyphoonCallStack.m
+++ b/Source/Factory/Internal/TyphoonCallStack.m
@@ -92,7 +92,7 @@
     return [self peekForKey:key args:args] != nil;
 }
 
-- (void)notifyOnceWhenStackEmptyUsingBlock:(void(^)())onEmpty
+- (void)notifyOnceWhenStackEmptyUsingBlock:(void(^)(void))onEmpty
 {
     [_emptyNotificationBlocks addObject:onEmpty];
 }
@@ -102,7 +102,7 @@
 
 - (void)callNotificationBlocksAndClear
 {
-    for (void(^notifyBlock)() in _emptyNotificationBlocks) {
+    for (void(^notifyBlock)(void) in _emptyNotificationBlocks) {
         notifyBlock();
     }
     [_emptyNotificationBlocks removeAllObjects];

--- a/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
+++ b/Tests/Factory/Assembly/TestAssemblies/MiddleAgesAssembly.m
@@ -408,7 +408,7 @@
 
 - (NSString *(^)(void))blockDefinition
 {
-    return [TyphoonDefinition with:^NSString *(){
+    return [TyphoonDefinition with:^NSString *(void){
         return @"321";
     }];
 }

--- a/Tests/Utils/TyphoonInvocationUtilsTestObjects.h
+++ b/Tests/Utils/TyphoonInvocationUtilsTestObjects.h
@@ -14,7 +14,7 @@
 
 @interface ObjectBlockArgument : NSObject
 
-+ (void)setBlock:(void(^)())block;
++ (void)setBlock:(void(^)(void))block;
 
 @end
 

--- a/Tests/Utils/TyphoonInvocationUtilsTestObjects.m
+++ b/Tests/Utils/TyphoonInvocationUtilsTestObjects.m
@@ -14,7 +14,7 @@
 
 @implementation ObjectBlockArgument
 
-+ (void)setBlock:(void (^)())block
++ (void)setBlock:(void (^)(void))block
 {
     block();
 }

--- a/Tests/Utils/TyphoonInvocationUtilsTests.m
+++ b/Tests/Utils/TyphoonInvocationUtilsTests.m
@@ -74,7 +74,7 @@
     NSObject *retainedObject = [NSObject new];
     
     NSInvocation *invocation = [TyphoonInvocationUtilsTests invocationForClassSelector:@selector(setBlock:) class:[ObjectBlockArgument class]];
-    void (^Block)() = ^{
+    void (^Block)(void) = ^{
         if (retainedObject) {
             ///
         }


### PR DESCRIPTION
Just changing the warnings this time with no changes to settings, this should now work for all targets without the need to update Xcode's recommended settings…
I did a search through the project and fixed all the ones I could find, hopefully I didn't miss any.