### PR TITLE
Add subscript methods to component pool protocol for fix building library on Xcode 9.3

### DIFF
--- a/Source/Factory/Pool/TyphoonComponentsPool.h
+++ b/Source/Factory/Pool/TyphoonComponentsPool.h
@@ -20,6 +20,10 @@
 
 - (id)objectForKey:(id <NSCopying>)aKey;
 
+- (id)objectForKeyedSubscript:(id <NSCopying>)aKey;
+
+- (void)setObject:(id)object forKeyedSubscript:(id <NSCopying>)aKey;
+
 - (NSArray *)allValues;
 
 - (void)removeAllObjects;


### PR DESCRIPTION
I tried to build library on Xcode 9.3 beta and received errors:

1) Expected method to read dictionary element not found on object of type 'id<TyphoonComponentsPool>'
2) Expected method to write dictionary element not found on object of type 'id<TyphoonComponentsPool>'

Adding subscript methods solves this problem.