### PR TITLE
Fix ViewControllerInjector for UITabBarController

### DIFF
--- a/Source/ios/Configuration/TyphoonViewControllerInjector.m
+++ b/Source/ios/Configuration/TyphoonViewControllerInjector.m
@@ -44,7 +44,11 @@
         [factory inject:viewController];
     }
     
-    for (UIViewController *controller in viewController.childViewControllers) {
+    NSArray<__kindof UIViewController *> *childViewControllers = [viewController isKindOfClass:UITabBarController.class]
+        ? ((UITabBarController *)viewController).viewControllers
+        : viewController.childViewControllers;
+
+    for (UIViewController *controller in childViewControllers) {
         if (storyboard && controller.storyboard && ![controller.storyboard isEqual:storyboard]) {
             continue;
         }


### PR DESCRIPTION
The UITabBarController's property childViewControllers only contains the visible tabs, when there are more than 4 tabs on a smaller screen a more tab gets created. This screws with the injection and ignores the tabs that are now in the more tab. This pull request tries to fix this issue by instead calling the UITabBarController's viewController property which does contain the other tabs.