### PR TITLE
Fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Visit <a href="http://appsquickly.github.io/Typhoon">the Typhoon website</a> for
 
 ## Is Typhoon the right DI framework for you? 
 
-Check out the <a href="http://www.typhoonframework.org/#features">feature list</a>. 
+Check out the <a href="http://appsquickly.github.io/Typhoon/#features">feature list</a>. 
 
 ### Looking for a pure Swift Solution?
 
@@ -45,7 +45,7 @@ let viewController = assembly.recommendationController() as! RecommendationContr
 # Installing 
 [![Build Status](https://travis-ci.org/appsquickly/Typhoon.svg?branch=master)](https://travis-ci.org/appsquickly/Typhoon)
 [![codecov](https://codecov.io/gh/appsquickly/Typhoon/branch/master/graph/badge.svg)](https://codecov.io/gh/appsquickly/Typhoon)
-![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/Typhoon/badge.png) [![Pod Platform](https://img.shields.io/cocoapods/p/Typhoon.svg?style=flat)](http://typhoonframework.org/docs/latest/api/modules.html) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Dependency Status](https://www.versioneye.com/objective-c/typhoon/1.1.1/badge.svg?style=flat)](https://www.versioneye.com/objective-c/typhoon) [![Pod License](https://img.shields.io/cocoapods/l/Typhoon.svg?style=flat)](https://github.com/appsquickly/Typhoon/blob/master/LICENSE)
+![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/Typhoon/badge.png) [![Pod Platform](https://img.shields.io/cocoapods/p/Typhoon.svg?style=flat)](http://appsquickly.github.io/Typhoon/docs/latest/api/modules.html) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Dependency Status](https://www.versioneye.com/objective-c/typhoon/1.1.1/badge.svg?style=flat)](https://www.versioneye.com/objective-c/typhoon) [![Pod License](https://img.shields.io/cocoapods/l/Typhoon.svg?style=flat)](https://github.com/appsquickly/Typhoon/blob/master/LICENSE)
 
 Typhoon is available through <a href="http://cocoapods.org/?q=Typhoon">CocoaPods</a> or <a href="https://github.com/Carthage/Carthage">Carthage</a>, and also builds easily from source.
 


### PR DESCRIPTION
I found some dead links while reading up on Typhoon. Switched "www.typhoonframework.org" to "appsquickly.github.io/Typhoon" in two places.

My assumption is that these just got missed and it's not a domain that is going to be renewed as per https://github.com/appsquickly/Typhoon/issues/580.