### PR TITLE
Fix API link on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
                     <li><a href="#faq">FAQ</a></li>
                     <li><a href="https://github.com/typhoon-framework/Typhoon/wiki/Types-of-Injections">User Guide</a>
                     </li>
-                    <li><a href="http://typhoonframework.org/docs/latest/api/group___assembly.html">API</a>
+                    <li><a href="docs/latest/api/group___assembly.html">API</a>
                     </li>
                 </ul>
             </section>


### PR DESCRIPTION
Fixes the API link on the Typhoon home page. Similar to #594 .